### PR TITLE
removing echo on the wrapper and adding gpg program by command line

### DIFF
--- a/git-gpg-wrapper.sh
+++ b/git-gpg-wrapper.sh
@@ -5,4 +5,4 @@
 # Required because git's gpg.program option doesn't allow you to set command
 # line options; see the doc/git-integration.md
 
-echo `dirname $0`/git-gpg-wrapper -- $@
+`dirname $0`/git-gpg-wrapper --gpg-program `which gpg` -- $@


### PR DESCRIPTION
On mac gpg is located at `/usr/local/bin/gpg`
I think using `which gpg` in the command line could be more interoperable