### PR TITLE
git-gpg-wrapper.sh: Fix the rare case when you have spaces

### DIFF
--- a/git-gpg-wrapper.sh
+++ b/git-gpg-wrapper.sh
@@ -5,4 +5,4 @@
 # Required because git's gpg.program option doesn't allow you to set command
 # line options; see the doc/git-integration.md
 
-`dirname $0`/git-gpg-wrapper --gpg-program `which gpg` -- $@
+"`dirname "$0"`"/git-gpg-wrapper --gpg-program "`which gpg`" -- "$@"


### PR DESCRIPTION
Now the wrapper works also if the path or the parameters includes
spaces