### PR TITLE
Added support for SOCKS5 proxy

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -16,15 +16,6 @@ Currently commitments are submitted to remote calendars sequentially; this
 should be done in parallel.
 
 
-## Tor Support
-
-Need to add an option to route all remote calendar queries through your local
-Tor proxy; see https://github.com/petertodd/dust-b-gone for an example
-implementation.
-
-Equally, it'd be good if remote calendars were accessible via onion addresses.
-
-
 ## "Sums" mode
 
 Useful to have a special mode for sha256sum output that built a tree of the

--- a/otsclient/args.py
+++ b/otsclient/args.py
@@ -69,6 +69,10 @@ def make_common_options_arg_parser():
     parser.add_argument("--wait-interval", action="store", type=int, default=30,
                         help=argparse.SUPPRESS) # best if users don't change this and DoS attack the calendars...
 
+    parser.add_argument("--socks5-proxy", dest="socks5_proxy",
+                        help="Route all traffic through a socks5 proxy, "
+                              "including DNS queries. The default port is 1080. Format: domain[:port] (ej localhost:9050)")
+
     return parser
 
 def handle_common_options(args, parser):

--- a/otsclient/cmds.py
+++ b/otsclient/cmds.py
@@ -16,17 +16,6 @@ import binascii
 import logging
 import os
 import time
-import socks
-import socket
-
-# Monkey patching create_connection too. This should prevent DNS leaks
-def create_connection(address, timeout=None, source_address=None):
-    sock = socks.socksocket()
-    sock.connect(address)
-    return sock
-
-socket.create_connection = create_connection
-
 import urllib.request
 import threading
 import bitcoin
@@ -48,24 +37,6 @@ from opentimestamps.bitcoin import *
 import opentimestamps.calendar
 
 import otsclient
-
-def install_socks5(proxy_url):
-    """Monkey patching socket library to redirect via SOCKS5"""
-    if isinstance(proxy_url, str):
-        e = proxy_url.split(':')
-        s5_hostname = e[0]
-        if len(e) > 1 and e[1].isdigit():
-            s5_port = int(e[1])
-        else:
-            s5_port = 1080
-        if not len(s5_hostname) > 0:
-            raise Exception("Malformed SOCKS5 proxy")
-        logging.info("Setting up SOCKS5 proxy: %s:%d" %
-                     (s5_hostname, s5_port))
-        socks.set_default_proxy(socks.SOCKS5,
-                                s5_hostname,
-                                s5_port)
-        socket.socket = socks.socksocket
 
 def remote_calendar(calendar_uri):
     """Create a remote calendar with User-Agent set appropriately"""
@@ -125,7 +96,7 @@ def create_timestamp(timestamp, calendar_urls, setup_bitcoin=False):
     for calendar_url in calendar_urls:
         timestamp.merge(q.get())
 
-# FIXME Async errors are not properly handled
+
 def submit_async(calendar_url, msg, q):
 
     def submit_async_thread(remote, msg, q):
@@ -139,8 +110,6 @@ def submit_async(calendar_url, msg, q):
 
 
 def stamp_command(args):
-    install_socks5(args.socks5_proxy)
-
     # Create initial commitment ops for all files
     file_timestamps = []
     merkle_roots = []

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 python-bitcoinlib>=0.7.0
 GitPython>=2.0.8
+PySocks>=1.5.7


### PR DESCRIPTION
Now you're able to use a SOCKS5 proxy as stated in the TODO file.
This will allow to route traffic via Tor (default SOCKS5 proxy-> 127.0.0.1:9050).
This will also allow to reach hidden service remove calendars because it routes DNS queries via the SOCKS5 proxy.

And thanks for the great project :smile: 