### PR TITLE
Add file close to avoid error on Windows

### DIFF
--- a/otsclient/cmds.py
+++ b/otsclient/cmds.py
@@ -343,6 +343,7 @@ def upgrade_command(args):
         ctx = StreamDeserializationContext(old_stamp_fd)
         try:
             detached_timestamp = DetachedTimestampFile.deserialize(ctx)
+            old_stamp_fd.close()
 
         # IOError's are already handled by argparse
         except BadMagicError:


### PR DESCRIPTION
Close file before rename it. 
On Windows without this, it was impossible to upgrade the .ots file:
`Could not backup timestamp: [WinError 32] The process cannot access the file because it is being used by another process:...`