### PR TITLE
Passing verbosity parameter to str_tree

### DIFF
--- a/otsclient/cmds.py
+++ b/otsclient/cmds.py
@@ -498,7 +498,7 @@ def info_command(args):
     print("File %s hash: %s" % (detached_timestamp.file_hash_op.HASHLIB_NAME, hexlify(detached_timestamp.file_digest).decode('utf8')))
 
     print("Timestamp:")
-    print(detached_timestamp.timestamp.str_tree())
+    print(detached_timestamp.timestamp.str_tree(verbosity=args.verbosity))
 
 
 


### PR DESCRIPTION
if verbosity parameter `-v`  is passed in the cli the str_tree is printed in verbose mode.
It requires https://github.com/opentimestamps/python-opentimestamps/pull/13 to be merged to work