### PR TITLE
add pysha3 to pip install reqs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 python-bitcoinlib>=0.7.0
 GitPython>=2.0.8
 PySocks>=1.5.0
+pysha3>=1.0.2


### PR DESCRIPTION
Not sure if this is best fix as I'm not python wizard, but fixed my issue importing `sha3` module.