### PR TITLE
Fix negative timeout crash

### DIFF
--- a/otsclient/cmds.py
+++ b/otsclient/cmds.py
@@ -108,7 +108,7 @@ def create_timestamp(timestamp, calendar_urls, args):
     merged = 0
     for i in range(n):
         try:
-            remaining = args.timeout - (time.time() - start)
+            remaining = max(0, args.timeout - (time.time() - start))
             result = q.get(block=True, timeout=remaining)
             try:
                 if isinstance(result, Timestamp):


### PR DESCRIPTION
Previously a timeout on one of the calendars could cause the following crash:

    Traceback (most recent call last):
      File "/home/user/src/ots/opentimestamps-client/ots-git-gpg-wrapper", line 133, in <module>
        otsclient.cmds.create_timestamp(final_timestamp, args.calendar_urls, args)
      File "/home/user/src/ots/opentimestamps-client/otsclient/cmds.py", line 111, in create_timestamp
        result = q.get(block=True, timeout=remaining)
      File "/usr/lib/python3.4/queue.py", line 169, in get
        raise ValueError("'timeout' must be a non-negative number")
    ValueError: 'timeout' must be a non-negative number

Ensuring the timeout is always non-negative fixes this.