### PR TITLE
Rework calendar whitelist handling

### DIFF
--- a/otsclient/cmds.py
+++ b/otsclient/cmds.py
@@ -280,10 +280,7 @@ def upgrade_timestamp(timestamp, args):
                         # logging.debug("Attestation URI %s overridden by user-specified remote calendar(s)" % attestation.uri)
                         pass
                     else:
-                        if args.whitelist is None:
-                            logging.warning("Ignoring attestation from calendar %s: Remote calendars disabled" % attestation.uri)
-                            continue
-                        elif attestation.uri in args.whitelist:
+                        if attestation.uri in args.whitelist:
                             calendar_urls = [attestation.uri]
                         else:
                             logging.warning("Ignoring attestation from calendar %s: Calendar not in whitelist" % attestation.uri)

--- a/python-opentimestamps/opentimestamps/calendar.py
+++ b/python-opentimestamps/opentimestamps/calendar.py
@@ -140,3 +140,16 @@ class UrlWhitelist(set):
 
         else:
             return False
+
+    def __repr__(self):
+       return 'UrlWhitelist([%s])' % ','.join("'%s'" % url.geturl() for url in self)
+
+DEFAULT_CALENDAR_WHITELIST = \
+    UrlWhitelist(['https://*.calendar.opentimestamps.org', # Run by Peter Todd
+                  'https://*.calendar.eternitywall.com',   # Run by Riccardo Casatta of Eternity Wall
+                 ])
+
+DEFAULT_AGGREGATORS = \
+    ('https://a.pool.opentimestamps.org',
+     'https://b.pool.opentimestamps.org',
+     'https://a.pool.eternitywall.com')

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,5 +1,14 @@
 # OpenTimestamps Client Release Notes
 
+## v0.5.0
+
+Breaking change: The remote calendar whitelist options have been reworked. The
+new behavior is that the `--whitelist` option adds additional remote calendars
+to the default whitelist. If you don't want to use the default whitelist, it
+can be disabled with the `--no-default-whitelist` option, replacing the prior
+`--no-remote-calendars` option, which no longer exists.
+
+
 ## v0.4.0
 
 Minor breaking change: `git-gpg-wrapper` now throws an error if


### PR DESCRIPTION
Breaking change!

While previously adding a non-default calendar with the `--whitelist` option would disable all the default calendars, now the `--whitelist` option adds to the default list; if you don't want the defaults, you can disable them with `--no-default-whitelist`

Also, the actual default itself has been moved to https://github.com/opentimestamps/python-opentimestamps/