### PR TITLE
Fix incorrect usage of "aggregator" when we mean "calendar"

### DIFF
--- a/ots-git-gpg-wrapper
+++ b/ots-git-gpg-wrapper
@@ -39,9 +39,13 @@ parser = otsclient.args.make_common_options_arg_parser()
 parser.add_argument("-g", "--gpg-program", action="store", default="/usr/bin/gpg",
                     help="Path to the GnuPG binary (default %(default)s)")
 
-parser.add_argument('-c','--calendar', metavar='URL', dest='calendar_urls', action='append', type=str,
-                    default=["https://a.pool.opentimestamps.org", "https://b.pool.opentimestamps.org", "https://a.pool.eternitywall.com"],
-                    help='Create timestamp with the aid of a remote calendar. May be specified multiple times. Default: %(default)r')
+parser.add_argument('-a', '--aggregator', metavar='URL', dest='aggregators', action='append', type=str,
+                    default=[],
+                    help='Add an aggregator')
+parser.add_argument('--no-default-aggregators', action='store_true', default=False,
+                    help='Do not use the default list of aggregators; '
+                         'use only aggregators manually added with --aggregator')
+
 parser.add_argument('-b','--btc-wallet', dest='use_btc_wallet', action='store_true',
                     help='Create timestamp locally with the local Bitcoin wallet.')
 parser.add_argument('--rehash-trees', action='store_true',
@@ -50,14 +54,12 @@ parser.add_argument("gpgargs", nargs=argparse.REMAINDER,
                     help='Arguments passed to GnuPG binary')
 
 parser.add_argument("--timeout", type=int, default=5,
-                              help="Timeout before giving up on a calendar. "
+                              help="Timeout before giving up on an aggregator. "
                                    "Default: %(default)d")
 
-parser.add_argument("-m", type=int, default="2",
-                              help="Commitments are sent to remote calendars,"
-                                   "in the event of timeout the timestamp is considered "
-                                   "done if at least M calendars replied. "
-                                   "Default: %(default)s")
+parser.add_argument("-m", type=int, metavar='M', default=2,
+                    help="Require at least M of the aggregators to respond for the "
+                         "timestamp to be considered complete. Default: %(default)d")
 
 args = otsclient.args.handle_common_options(parser.parse_args(), parser)
 
@@ -134,7 +136,7 @@ if gpgargs.bsau:
             final_timestamp = signed_commit_timestamp.ops.add(OpAppend(tree_stamper.timestamp.msg)).ops.add(OpSHA256())
             minor_version = 1
 
-        otsclient.cmds.create_timestamp(final_timestamp, args.calendar_urls, args)
+        otsclient.cmds.create_timestamp(final_timestamp, args)
 
         if args.wait:
             # Interpreted as override by the upgrade command

--- a/otsclient/args.py
+++ b/otsclient/args.py
@@ -160,9 +160,13 @@ def parse_ots_args(raw_args):
     parser_stamp = subparsers.add_parser('stamp', aliases=['s'],
                                          help='Timestamp files')
 
-    parser_stamp.add_argument('-c', '--calendar', metavar='URL', dest='calendar_urls', action='append', type=str,
+    parser_stamp.add_argument('-a', '--aggregator', metavar='URL', dest='aggregators', action='append', type=str,
                               default=[],
-                              help='Create timestamp with the aid of a remote calendar. May be specified multiple times.')
+                              help='Add an aggregator')
+
+    parser_stamp.add_argument('--no-default-aggregators', action='store_true', default=False,
+                              help='Do not use the default list of aggregators; '
+                                   'use only aggregators manually added with --aggregator')
 
     parser_stamp.add_argument('-b', '--btc-wallet', dest='use_btc_wallet', action='store_true',
                               help='Create timestamp locally with the local Bitcoin wallet.')
@@ -172,14 +176,12 @@ def parse_ots_args(raw_args):
                               help='Filename')
 
     parser_stamp.add_argument("--timeout", type=int, default=5,
-                              help="Timeout before giving up on a calendar. "
+                              help="Timeout (in seconds) before giving up on an aggregator. "
                                    "Default: %(default)d")
 
-    parser_stamp.add_argument("-m", type=int, default="2",
-                              help="Commitments are sent to remote calendars,"
-                                   "in the event of timeout the timestamp is considered "
-                                   "done if at least M calendars replied. "
-                                   "Default: %(default)s")
+    parser_stamp.add_argument("-m", type=int, metavar='M', default=2,
+                              help="Require at least M of the aggregators to respond for the "
+                                   "timestamp to be considered complete. Default: %(default)d")
 
     # ----- upgrade -----
     parser_upgrade = subparsers.add_parser('upgrade', aliases=['u'],

--- a/otsclient/cmds.py
+++ b/otsclient/cmds.py
@@ -280,10 +280,7 @@ def upgrade_timestamp(timestamp, args):
                         # logging.debug("Attestation URI %s overridden by user-specified remote calendar(s)" % attestation.uri)
                         pass
                     else:
-                        if args.whitelist is None:
-                            logging.warning("Ignoring attestation from calendar %s: Remote calendars disabled" % attestation.uri)
-                            continue
-                        elif attestation.uri in args.whitelist:
+                        if attestation.uri in args.whitelist:
                             calendar_urls = [attestation.uri]
                         else:
                             logging.warning("Ignoring attestation from calendar %s: Calendar not in whitelist" % attestation.uri)

--- a/python-opentimestamps/opentimestamps/calendar.py
+++ b/python-opentimestamps/opentimestamps/calendar.py
@@ -140,3 +140,16 @@ class UrlWhitelist(set):
 
         else:
             return False
+
+    def __repr__(self):
+       return 'UrlWhitelist([%s])' % ','.join("'%s'" % url.geturl() for url in self)
+
+DEFAULT_CALENDAR_WHITELIST = \
+    UrlWhitelist(['https://*.calendar.opentimestamps.org', # Run by Peter Todd
+                  'https://*.calendar.eternitywall.com',   # Run by Riccardo Casatta of Eternity Wall
+                 ])
+
+DEFAULT_AGGREGATORS = \
+    ('https://a.pool.opentimestamps.org',
+     'https://b.pool.opentimestamps.org',
+     'https://a.pool.eternitywall.com')

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,5 +1,14 @@
 # OpenTimestamps Client Release Notes
 
+## v0.5.0
+
+Breaking change: The remote calendar whitelist options have been reworked. The
+new behavior is that the `--whitelist` option adds additional remote calendars
+to the default whitelist. If you don't want to use the default whitelist, it
+can be disabled with the `--no-default-whitelist` option, replacing the prior
+`--no-remote-calendars` option, which no longer exists.
+
+
 ## v0.4.0
 
 Minor breaking change: `git-gpg-wrapper` now throws an error if

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,12 +1,30 @@
 # OpenTimestamps Client Release Notes
 
-## v0.5.0
+## v0.5.0-PENDING
 
-Breaking change: The remote calendar whitelist options have been reworked. The
+### Breaking Change: Calendar Whitelists
+
+The remote calendar whitelist options have been reworked. The
 new behavior is that the `--whitelist` option adds additional remote calendars
 to the default whitelist. If you don't want to use the default whitelist, it
 can be disabled with the `--no-default-whitelist` option, replacing the prior
 `--no-remote-calendars` option, which no longer exists.
+
+Previously the default whitelist was only loaded if `--whitelist` wasn't used
+at all, making it the client inconvenient to use if you wanted to be able to
+verify timestamps using both standard and non-standard calendars at the same
+time.
+
+
+### Breaking Change: Aggregators
+
+Previously commands that created timestamps incorrectly used the term
+"calendar" when they should have used the term "aggregator" in both
+documentation and command line options. This version fixes that oversight by
+renaming the `--calendar` options of the `stamp` subcommand and
+`ots-git-gpg-wrapper` to `--aggregator`. As with the new calendar whitelist
+options, there's a default list of aggregators that can be disabled with the
+`--no-default-aggregators` option.
 
 
 ## v0.4.0


### PR DESCRIPTION
Building on #59, this pull-req changes the stamp subcommand and git wrapper to use the terminology "aggregator" rather than "calendar" to refer to the servers that aggregate digests into per-second merkle tree commitments.

That said, I'm not totally convinced this distinction is useful... Possibly it'd be better to drop the idea of an "aggregator" and stick with "calendar"