### PR TITLE
Use appdirs library to determine dir locations

### DIFF
--- a/otsclient/args.py
+++ b/otsclient/args.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2016 The OpenTimestamps developers
+# Copyright (C) 2016-2018 The OpenTimestamps developers
 #
 # This file is part of the OpenTimestamps Client.
 #
@@ -9,12 +9,13 @@
 # modified, propagated, or distributed except according to the terms contained
 # in the LICENSE file.
 
+import appdirs
 import argparse
 import bitcoin
 import logging
 import os
-import sys
 import socket
+import sys
 
 import opentimestamps.calendar
 
@@ -22,6 +23,7 @@ import otsclient
 import otsclient.cache
 import otsclient.cmds
 
+APPDIRS = appdirs.AppDirs('ots','opentimestamps')
 
 def make_common_options_arg_parser():
     parser = argparse.ArgumentParser(description="OpenTimestamps client.")
@@ -42,7 +44,7 @@ def make_common_options_arg_parser():
     cache_group  = parser.add_mutually_exclusive_group()
     cache_group.add_argument("--cache", action="store", type=str,
                              dest='cache_path',
-                             default='~/.cache/ots',
+                             default=APPDIRS.user_cache_dir,
                              help="Location of the timestamp cache. Default: %(default)s")
     cache_group.add_argument("--no-cache", action="store_const", const=None,
                              dest='cache_path',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 opentimestamps>=0.2.0,<0.3.0
+appdirs>=1.3.0
 GitPython>=2.0.8
 PySocks>=1.5.0

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ setup(
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=['opentimestamps>=0.2.0,<0.3.0',
+                      'appdirs>=1.3.0',
                       'GitPython>=2.0.8',
                       'PySocks>=1.5.0'],
 


### PR DESCRIPTION
Currently only applicable to the `~/.cache/ots` directory; changes behavior from previous on MacOS and Windows.

@RCasatta IIRC you have a Mac; mind testing that this works properly on it? I want to make this change to in the future use appropriate appdirs for config files.