### PR TITLE
Display block height and merkle root if --no-bitcoin

### DIFF
--- a/otsclient/cmds.py
+++ b/otsclient/cmds.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2016 The OpenTimestamps developers
+# Copyright (C) 2016-2018 The OpenTimestamps developers
 #
 # This file is part of the OpenTimestamps Client.
 #
@@ -401,6 +401,8 @@ def verify_timestamp(timestamp, args):
         elif attestation.__class__ == BitcoinBlockHeaderAttestation:
             if not args.use_bitcoin:
                 logging.warning("Not checking Bitcoin attestation; Bitcoin disabled")
+                logging.info("To verify manually, check that Bitcoin block %d has merkleroot %s" %
+                                (attestation.height, b2lx(msg)))
                 continue
 
             proxy = args.setup_bitcoin()


### PR DESCRIPTION
Allows for manual verification of timestamps without a local Bitcoin node.