### PR TITLE
Display Bitcoin timestamps with appropriate precision

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,11 +151,6 @@ Use the setuptools development mode:
 
 ## Known Issues
 
-* Displaying Bitcoin timestamps down to the second is false precision, and
-  misleading. But rounding off to the nearest day is over-doing it in the other
-  direction. See https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2016-September/013120.html
-  for more information on this issue.
-
 * Need unit tests for the client.
 
 * Git tree re-hashing support fails on certain filenames with invalid unicode

--- a/otsclient/cmds.py
+++ b/otsclient/cmds.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2016 The OpenTimestamps developers
+# Copyright (C) 2016-2018 The OpenTimestamps developers
 #
 # This file is part of the OpenTimestamps Client.
 #
@@ -425,8 +425,10 @@ def verify_timestamp(timestamp, args):
                 logging.error("Bitcoin verification failed: %s" % str(err))
                 continue
 
-            logging.info("Success! Bitcoin attests data existed as of %s" %
-                         time.strftime('%c %Z', time.localtime(attested_time)))
+            logging.info("Success! Bitcoin block %d attests existence as of %s" %
+                            (attestation.height,
+                             time.strftime('%Y-%m-%d %Z',
+                                          time.localtime(attested_time))))
             good = True
 
             # One Bitcoin attestation is enough


### PR DESCRIPTION
Previously would display them with precision down to the second, which misrepresents how precise a Bitcoin timestamp can actually be as adversarial miners can get away with creating blocks whose timestamps are inaccurate by multiple hours or more.

For those who do want a more precise timestamp, the height of the block attesting to the timestamp is now displayed, allowing a manual investigation of it.

Examples of the new UX:

```
$ ots verify examples/empty.ots 
Assuming target filename is 'examples/empty'
Success! Bitcoin block 129405 attests existence as of 2011-06-08 EDT
```

```
$ git tag -v opentimestamps-client-v0.5.1
object dcc45495b682c522170e8c2148b4759632e9d7fa
type commit
tag opentimestamps-client-v0.5.1
tagger Peter Todd <pete@petertodd.org> 1513029381 -0500

Release opentimestamps-client-v0.5.1
ots: Got 1 attestation(s) from https://finney.calendar.eternitywall.com
ots: Got 1 attestation(s) from https://bob.btc.calendar.opentimestamps.org
ots: Success! Bitcoin block 498825 attests existence as of 2017-12-11 EST
ots: Good timestamp
gpg: Signature made Mon 11 Dec 2017 04:56:22 PM EST
gpg:                using RSA key 2481403DA5F091FB
gpg: Good signature from "Peter Todd <pete@petertodd.org>"
gpg:                 aka "[jpeg image of size 5220]"
```