### PR TITLE
add prune command

### DIFF
--- a/otsclient/args.py
+++ b/otsclient/args.py
@@ -216,12 +216,32 @@ def parse_ots_args(raw_args):
     parser_info.add_argument('file', metavar='FILE', type=argparse.FileType('rb'),
                              help='Filename')
 
+    # ----- prune -----
+    parser_prune = subparsers.add_parser('prune', aliases=['p'],
+                                         help='Prune timestamp')
+
+    prune_verify_group = parser_prune.add_mutually_exclusive_group()
+    prune_verify_group.add_argument('--verify', dest='attestations_to_verify', metavar='NOTARYSPEC', action='append',
+                                    type=str, default=[],
+                                    help='Verify attestations from a specified notary. May be specified multiple times.'
+                                         ' Default btc.')
+    prune_verify_group.add_argument('--no-verify', dest='no_verify', action='store_true', default=False,
+                                    help='Do not verify any attestation.')
+
+    parser_prune.add_argument('--discard', dest='attestations_to_discard', metavar='NOTARYSPEC', action='append',
+                              type=str, default=[],
+                              help='Discard attestations from a specified notary. May be specified multiple times. '
+                                   'Default pending:*.')
+
+    parser_prune.add_argument('timestamp_fd', metavar='TIMESTAMP', type=argparse.FileType('rb'),
+                              help='Existing timestamp; moved to TIMESTAMP.bak')
 
 
     parser_stamp.set_defaults(cmd_func=otsclient.cmds.stamp_command)
     parser_upgrade.set_defaults(cmd_func=otsclient.cmds.upgrade_command)
     parser_verify.set_defaults(cmd_func=otsclient.cmds.verify_command)
     parser_info.set_defaults(cmd_func=otsclient.cmds.info_command)
+    parser_prune.set_defaults(cmd_func=otsclient.cmds.prune_command)
 
     try:
         import git

--- a/otsclient/tests/test_prune.py
+++ b/otsclient/tests/test_prune.py
@@ -1,0 +1,114 @@
+# Copyright (C) 2018 The OpenTimestamps developers
+#
+# This file is part of the OpenTimestamps Client.
+#
+# It is subject to the license terms in the LICENSE file found in the top-level
+# directory of this distribution.
+#
+# No part of the OpenTimestamps Client, including this file, may be copied,
+# modified, propagated, or distributed except according to the terms contained
+# in the LICENSE file.
+
+import unittest
+from opentimestamps.core.timestamp import Timestamp
+from opentimestamps.core.op import OpAppend
+from opentimestamps.core.notary import BitcoinBlockHeaderAttestation, LitecoinBlockHeaderAttestation, \
+    PendingAttestation, UnknownAttestation
+from otsclient.cmds import discard_attestations, discard_suboptimal, prune_tree, prune_timestamp
+
+
+class TestPrune(unittest.TestCase):
+
+    def test_discard_attestations(self):
+        """Discarding attestations"""
+        t = Timestamp(b'')
+        t1 = t.ops.add(OpAppend(b'\x01'))
+        t2 = t.ops.add(OpAppend(b'\x02'))
+        t.attestations = {UnknownAttestation(b'unknown.', b'')}
+        t1.attestations = {BitcoinBlockHeaderAttestation(1)}
+        t2.attestations = {PendingAttestation("c2"), PendingAttestation("c1")}
+
+        discard_attestations(t, [UnknownAttestation, PendingAttestation("c1")])
+
+        tn = Timestamp(b'')
+        tn1 = tn.ops.add(OpAppend(b'\x01'))
+        tn2 = tn.ops.add(OpAppend(b'\x02'))
+        tn1.attestations = {BitcoinBlockHeaderAttestation(1)}
+        tn2.attestations = {PendingAttestation("c2")}
+
+        self.assertEqual(t, tn)
+
+    def test_discard_suboptimal(self):
+        """Discarding suboptimal attestations"""
+        t = Timestamp(b'')
+        t1 = t.ops.add(OpAppend(b'\x01'))
+        t2 = t.ops.add(OpAppend(b'\x02'))
+        t3 = t.ops.add(OpAppend(b'\x03\03'))
+        t4 = t.ops.add(OpAppend(b'\x04'))
+        t1.attestations = {BitcoinBlockHeaderAttestation(2)}
+        t2.attestations = {BitcoinBlockHeaderAttestation(1)}
+        t3.attestations = {LitecoinBlockHeaderAttestation(1)}
+        t4.attestations = {LitecoinBlockHeaderAttestation(1)}
+
+        discard_suboptimal(t, BitcoinBlockHeaderAttestation)
+        discard_suboptimal(t, LitecoinBlockHeaderAttestation)
+
+        tn = Timestamp(b'')
+        tn1 = tn.ops.add(OpAppend(b'\x01'))
+        tn2 = tn.ops.add(OpAppend(b'\x02'))
+        tn3 = tn.ops.add(OpAppend(b'\x03\03'))
+        tn4 = tn.ops.add(OpAppend(b'\x04'))
+        tn2.attestations = {BitcoinBlockHeaderAttestation(1)}
+        tn4.attestations = {LitecoinBlockHeaderAttestation(1)}
+
+        self.assertEqual(t, tn)
+
+    def test_prune_tree(self):
+        """Pruning tree"""
+        t = Timestamp(b'')
+
+        empty, changed = prune_tree(t)
+
+        self.assertTrue(empty)
+        self.assertFalse(changed)
+
+        t1 = t.ops.add(OpAppend(b'\x01'))
+        t2 = t.ops.add(OpAppend(b'\x02'))
+        t1.attestations = {PendingAttestation("c")}
+
+        empty, changed = prune_tree(t)
+
+        tn = Timestamp(b'')
+        tn1 = tn.ops.add(OpAppend(b'\x01'))
+        tn1.attestations = {PendingAttestation("c")}
+
+        self.assertEqual(t, tn)
+        self.assertFalse(empty)
+        self.assertTrue(changed)
+
+        _, changed = prune_tree(t)
+
+        self.assertFalse(changed)
+
+    def test_pruning_timestamp(self):
+        """Pruning timestamp"""
+        t = Timestamp(b'')
+        t1 = t.ops.add(OpAppend(b'\x01'))
+        t2 = t.ops.add(OpAppend(b'\x02'))
+        t3 = t.ops.add(OpAppend(b'\x03'))
+        t21 = t2.ops.add(OpAppend(b'\x02'))
+        t31 = t3.ops.add(OpAppend(b'\x03'))
+        t1.attestations = {PendingAttestation("c1")}
+        t2.attestations = {PendingAttestation("c2")}
+        t3.attestations = {PendingAttestation("c3")}
+        t21.attestations = {BitcoinBlockHeaderAttestation(2)}
+        t31.attestations = {BitcoinBlockHeaderAttestation(1)}
+
+        prune_timestamp(t, [], [PendingAttestation], None)
+
+        tn = Timestamp(b'')
+        tn3 = tn.ops.add(OpAppend(b'\x03'))
+        tn31 = tn3.ops.add(OpAppend(b'\x03'))
+        tn31.attestations = {BitcoinBlockHeaderAttestation(1)}
+
+        self.assertEqual(t, tn)


### PR DESCRIPTION
Add prune command as described in https://github.com/opentimestamps/opentimestamps-client/issues/88.

Note that, to properly run the tests, it is needed a version of python-opentimestamps > v.0.3.0, since timestamp equality is used.