### PR TITLE
Implement watchlist cache and runtime cache

### DIFF
--- a/otsclient/args.py
+++ b/otsclient/args.py
@@ -195,6 +195,14 @@ def parse_ots_args(raw_args):
                                 nargs='+',
                                 help='Existing timestamp(s); moved to FILE.bak')
 
+    parser_upgradewatchlist = subparsers.add_parser('upgradewatchlist', aliases=['uw'],
+                                                    help="Upgrade timestamps from cache")
+    parser_upgradewatchlist.add_argument('-c', '--calendar', metavar='URL', dest='calendar_urls', action='append', type=str,
+                                         default=[],
+                                         help='Override calendars in timestamps')
+    parser_upgradewatchlist.add_argument('-n', '--dry-run', action='store_true', default=False,
+                                         help='Perform a trial upgrade without modifying the existing timestamps.')
+
     # ----- verify -----
     parser_verify = subparsers.add_parser('verify', aliases=['v'],
                                           help="Verify a timestamp")
@@ -239,6 +247,7 @@ def parse_ots_args(raw_args):
 
     parser_stamp.set_defaults(cmd_func=otsclient.cmds.stamp_command)
     parser_upgrade.set_defaults(cmd_func=otsclient.cmds.upgrade_command)
+    parser_upgradewatchlist.set_defaults(cmd_func=otsclient.cmds.upgradewatchlist_command)
     parser_verify.set_defaults(cmd_func=otsclient.cmds.verify_command)
     parser_info.set_defaults(cmd_func=otsclient.cmds.info_command)
     parser_prune.set_defaults(cmd_func=otsclient.cmds.prune_command)

--- a/otsclient/cache.py
+++ b/otsclient/cache.py
@@ -90,3 +90,35 @@ class TimestampCache:
 
         existing.merge(new_timestamp)
         self.__save(existing)
+
+    def __get_watchlist_path(self):
+        watchlist_path = os.path.join(self.path, "watchlist")
+        return watchlist_path
+
+    def watch(self, ots_filepath):
+        watchlist_path = self.__get_watchlist_path()
+        with open(watchlist_path, "a") as watchlist_fd:
+            watchlist_fd.write(ots_filepath)
+            watchlist_fd.write("\n")
+        return True
+
+    def unwatch(self, watchlist, ots_filepaths):
+        watchlist_path = self.__get_watchlist_path()
+        with open(watchlist_path, "w") as watchlist_fd:
+            for watch_item in watchlist:
+                if watch_item in ots_filepaths:
+                    continue
+                watchlist_fd.write(watch_item)
+                watchlist_fd.write("\n")
+        return True
+
+    def watchlist(self):
+        watchlist_path = self.__get_watchlist_path()
+
+        if not os.path.exists(watchlist_path):
+            return []
+
+        with open(watchlist_path, "r") as watchlist_fd:
+            watchlist_content = watchlist_fd.read()
+            watchlist_items = watchlist_content.split("\n")
+            return [watchlist_item for watchlist_item in watchlist_items if watchlist_item != ""]

--- a/otsclient/cmds.py
+++ b/otsclient/cmds.py
@@ -204,6 +204,9 @@ def stamp_command(args):
             with special_output_fd or open(timestamp_file_path, 'xb') as timestamp_fd:
                 ctx = StreamSerializationContext(timestamp_fd)
                 file_timestamp.serialize(ctx)
+
+                # add this timestamp to the watchlist
+                args.cache.watch(os.path.abspath(timestamp_file_path))
         except IOError as exp:
             logging.error("Failed to create timestamp %r: %s" % (timestamp_file_path, exp))
             sys.exit(1)
@@ -226,6 +229,9 @@ def upgrade_timestamp(timestamp, args):
     Note that this means if the timestamp that is already complete, False will
     be returned as nothing has changed.
     """
+
+    if not hasattr(args, "runtime_cache"):
+        args.runtime_cache = {}
 
     def directly_verified(stamp):
         if stamp.attestations:
@@ -272,6 +278,15 @@ def upgrade_timestamp(timestamp, args):
         # agressive.
         found_new_attestations = False
         for sub_stamp in directly_verified(timestamp):
+            commitment = sub_stamp.msg
+
+            # If the runtime cache already indicates that calendar servers have
+            # been checked and there are no mature timestamps available, then
+            # don't check the servers a second time during this run.
+            if b2x(commitment) in args.runtime_cache.keys() and args.runtime_cache[b2x(commitment)] == False:
+                logging.info("Runtime cache indicates timestamp not complete")
+                continue
+
             for attestation in sub_stamp.attestations:
                 if attestation.__class__ == PendingAttestation:
                     calendar_urls = args.calendar_urls
@@ -287,7 +302,6 @@ def upgrade_timestamp(timestamp, args):
                             logging.warning("Ignoring attestation from calendar %s: Calendar not in whitelist" % attestation.uri)
                             continue
 
-                    commitment = sub_stamp.msg
                     for calendar_url in calendar_urls:
                         logging.debug("Checking calendar %s for %s" % (attestation.uri, b2x(commitment)))
                         calendar = remote_calendar(calendar_url)
@@ -317,6 +331,10 @@ def upgrade_timestamp(timestamp, args):
                             args.cache.merge(upgraded_stamp)
                             sub_stamp.merge(upgraded_stamp)
 
+                    if changed == False:
+                        # commitment not timestamped in any of the calendars
+                        args.runtime_cache[b2x(commitment)] = False
+
         if not args.wait:
             break
 
@@ -334,8 +352,30 @@ def upgrade_timestamp(timestamp, args):
 
 
 def upgrade_command(args):
+
+    # defer certain sys.exit(1) calls until later
+    error = False
+
+    completed_timestamps = []
+
+    # Timestamp commitment cash that exists only during active processing.
+    # Don't check calendar servers multiple times for the same commitment.
+    args.runtime_cache = {}
+
     for old_stamp_fd in args.files:
-        logging.debug("Upgrading %s" % old_stamp_fd.name)
+        # Bypass file descriptor limit by opening a file one at a time when a
+        # filepath is given instead of a file descriptor.
+        if isinstance(old_stamp_fd, str):
+            filepath = old_stamp_fd
+            try:
+                old_stamp_fd = open(filepath, "rb")
+                logging.info("Upgrading %s" % filepath)
+            except FileNotFoundError:
+                logging.error("Error! Failed to open file %r" % filepath)
+                error = True
+                continue
+        else:
+            logging.debug("Upgrading %s" % old_stamp_fd.name)
 
         ctx = StreamDeserializationContext(old_stamp_fd)
         try:
@@ -345,10 +385,12 @@ def upgrade_command(args):
         # IOError's are already handled by argparse
         except BadMagicError:
             logging.error("Error! %r is not a timestamp file" % old_stamp_fd.name)
-            sys.exit(1)
+            error = True
+            continue
         except DeserializationError as exp:
             logging.error("Invalid timestamp file %r: %s" % (old_stamp_fd.name, exp))
-            sys.exit(1)
+            error = True
+            continue
 
         changed = upgrade_timestamp(detached_timestamp.timestamp, args)
 
@@ -358,13 +400,15 @@ def upgrade_command(args):
 
             if os.path.exists(backup_name):
                 logging.error("Could not backup timestamp: %r already exists" % backup_name)
-                sys.exit(1)
+                error = True
+                continue
 
             try:
                 os.rename(old_stamp_fd.name, backup_name)
             except IOError as exp:
                 logging.error("Could not backup timestamp: %s" % exp)
-                sys.exit(1)
+                error = True
+                continue
 
             try:
                 with open(old_stamp_fd.name, 'xb') as new_stamp_fd:
@@ -373,14 +417,30 @@ def upgrade_command(args):
             except IOError as exp:
                 # FIXME: should we try to restore the old file here?
                 logging.error("Could not upgrade timestamp %s: %s" % (old_stamp_fd.name, exp))
-                sys.exit(1)
+                error = True
+                continue
 
         if is_timestamp_complete(detached_timestamp.timestamp, args):
             logging.info("Success! Timestamp complete")
+            completed_timestamps.append(os.path.abspath(old_stamp_fd.name))
         else:
             logging.warning("Failed! Timestamp not complete")
-            sys.exit(1)
+            error = True
+            continue
 
+    # remove old entries from the watchlist
+    if not args.dry_run:
+        old_watchlist = args.cache.watchlist()
+        args.cache.unwatch(old_watchlist, completed_timestamps)
+
+    if error:
+        logging.error("Encountered an earlier error. Exiting.")
+        sys.exit(1)
+
+
+def upgradewatchlist_command(args):
+    args.files = [filename for filename in args.cache.watchlist() if filename != ""]
+    return upgrade_command(args)
 
 def verify_timestamp(timestamp, args):
     args.calendar_urls = []


### PR DESCRIPTION
# Overview

Sometimes I forget to upgrade my timestamps, and I'd like to keep them upgraded. Instead of searching my filesystem for all immature timestamps, why not track them with the ots cache?

Various other improvements are included, as described below.

Note that it may be prudent to refactor the `upgradewatchlist` command to be responsible for removing items from the watchlist, instead of the `upgrade` command. Doing this in the `upgrade` command might be very slow when the watchlist is enormous, which would make for a bad user experience when the user is only trying to upgrade a single timestamp. However, it is not clear why a user would prefer to upgrade a single timestamp and not all timestamps anyway...

# Commit message

A watchlist cache is implemented. The watchlist is a list of immature timestamp files that should be upgraded at a later time. When a file is timestamped, its file path is added to the watchlist. The file is removed from the watchlist once it has been successfully upgraded.

Immature timestamps no longer immediately cause exit of the program, and instead an error is sent to stderr followed by a continuance of the program until the very end when the program exits with exit(1).

A runtime cache is implemented. It is based on the premise that it is unlikely that a timestamp will be upgraded in the time that it takes to run the whole command, so the calendar servers will only be checked once per each new commitment. This is particularly useful for bulk upgrading of timestamps. If "immediate exit" was still implemented, this would not be possible. Without a runtime cache, checking each timestamp against each calendar server-- even with the same root commitment-- would be unbearably slow.