### PR TITLE
feat: show time for verify

### DIFF
--- a/otsclient/cmds.py
+++ b/otsclient/cmds.py
@@ -430,7 +430,7 @@ def verify_timestamp(timestamp, args):
 
             logging.info("Success! Bitcoin block %d attests existence as of %s" %
                             (attestation.height,
-                             time.strftime('%Y-%m-%d %Z',
+                             time.strftime('%Y-%m-%dT%H:%M:%S %Z',
                                           time.localtime(attested_time))))
             good = True
 


### PR DESCRIPTION
The `verify` command tells the date of verification but not the time.
Add time to the output because it's a sane default: _time_ stamps should
show time.