### PR TITLE
Fix and improve solo stamping

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,25 @@ commitment operations and attestations in it:
         append 647b90ea1b270a97
         verify PendingAttestation('https://bob.btc.calendar.opentimestamps.org')
 
+### Timestamping without a calendar service with your own wallet
+
+It's possible to create a timestamp using your own Bitcoin Core wallet. This
+is generally not necessary, can harm your privacy and is somewhat risky because
+the code is not well tested.
+
+Use the `--btc-wallet` argument after `stamp` command to use this feature,
+optionally specifying a fee rate in sat/vbyte with `--fee-rate`.
+
+If the process is interrupted, a `.ots.pending` recovery file is written so
+stamping resumes automatically. Alternatively use `--txid` and `--nonce`.
+
+It's possible to RBF the resulting transaction while waiting for confirmation.
+
+For multi-wallet setups, specify the wallet name in the node URL:
+`--bitcoin-node http://user:pass@localhost:8332/wallet/NAME`
+
+See `ots stamp --help` for more info.
+
 ### Timestamping and Verifying PGP Signed Git Commits
 
 See `doc/git-integration.md`

--- a/otsclient/args.py
+++ b/otsclient/args.py
@@ -54,6 +54,9 @@ def make_common_options_arg_parser():
     btc_net_group.add_argument('--btc-testnet', dest='btc_net', action='store_const',
                                const='testnet', default='mainnet',
                                help='Use Bitcoin testnet rather than mainnet')
+    btc_net_group.add_argument('--btc-signet', dest='btc_net', action='store_const',
+                               const='signet', default='mainnet',
+                               help='Use Bitcoin signet rather than mainnet')
     btc_net_group.add_argument('--btc-regtest', dest='btc_net', action='store_const',
                                const='regtest',
                                help='Use Bitcoin regtest rather than mainnet')
@@ -135,6 +138,8 @@ def handle_common_options(args, parser):
         """
         if args.btc_net == 'testnet':
            bitcoin.SelectParams('testnet')
+        elif args.btc_net == 'signet':
+           bitcoin.SelectParams('signet')
         elif args.btc_net == 'regtest':
            bitcoin.SelectParams('regtest')
         elif args.btc_net == 'mainnet':

--- a/otsclient/args.py
+++ b/otsclient/args.py
@@ -172,6 +172,12 @@ def parse_ots_args(raw_args):
     parser_stamp.add_argument('-f', '--fee-rate', dest='fee_rate', type=float, default=None,
                               help='Specify fee rate in sat/vbyte. Default is to let Bitcoin Core decide.')
 
+    parser_stamp.add_argument('--nonce', dest='nonce', default=None,
+                              help='Resume earlier stamp, must be used together with --txid')
+
+    parser_stamp.add_argument('--txid', dest='txid', default=None,
+                              help='Resume earlier stamp, must be used together with --nonce. Can be used with RBF.')
+
     parser_stamp.add_argument('files', metavar='FILE', type=argparse.FileType('rb'),
                               nargs='*',
                               help='Filename')
@@ -264,6 +270,11 @@ def parse_ots_args(raw_args):
         pass
 
     args = parser.parse_args(raw_args)
+
+    if hasattr(args, "nonce") or hasattr(args, "txid"):
+        if (args.nonce is not None) != (args.txid is not None):
+            parser_stamp.error('--nonce and --txid must be given together')
+
     args = handle_common_options(args, parser)
 
     return args

--- a/otsclient/args.py
+++ b/otsclient/args.py
@@ -169,6 +169,9 @@ def parse_ots_args(raw_args):
     parser_stamp.add_argument('-b', '--btc-wallet', dest='use_btc_wallet', action='store_true',
                               help='Create timestamp locally with the local Bitcoin wallet.')
 
+    parser_stamp.add_argument('-f', '--fee-rate', dest='fee_rate', type=float, default=None,
+                              help='Specify fee rate in sat/vbyte. Default is to let Bitcoin Core decide.')
+
     parser_stamp.add_argument('files', metavar='FILE', type=argparse.FileType('rb'),
                               nargs='*',
                               help='Filename')

--- a/otsclient/cmds.py
+++ b/otsclient/cmds.py
@@ -57,14 +57,17 @@ def create_timestamp(timestamp, calendar_urls, args):
     if setup_bitcoin:
         proxy = setup_bitcoin()
 
+        logging.debug("Call fundrawtransaction for OP_RETURN %s", timestamp.msg.hex())
         unfunded_tx = CTransaction([], [CTxOut(0, CScript([OP_RETURN, timestamp.msg]))])
         r = proxy.fundrawtransaction(unfunded_tx)  # FIXME: handle errors
         funded_tx = r['tx']
 
-        r = proxy.signrawtransaction(funded_tx)
+        logging.debug("Call signrawtransactionwithwallet %s", funded_tx.serialize().hex())
+        r = proxy.signrawtransactionwithwallet(funded_tx)
         assert r['complete']
         signed_tx = r['tx']
 
+        logging.debug("Call sendrawtransaction %s", signed_tx.serialize().hex())
         txid = proxy.sendrawtransaction(signed_tx)
         logging.info('Sent timestamp tx')
 

--- a/otsclient/cmds.py
+++ b/otsclient/cmds.py
@@ -59,7 +59,12 @@ def create_timestamp(timestamp, calendar_urls, args):
 
         logging.debug("Call fundrawtransaction for OP_RETURN %s", timestamp.msg.hex())
         unfunded_tx = CTransaction([], [CTxOut(0, CScript([OP_RETURN, timestamp.msg]))])
-        r = proxy.fundrawtransaction(unfunded_tx)  # FIXME: handle errors
+
+        options = {}
+        if args.fee_rate is not None:
+            options['fee_rate'] = args.fee_rate
+
+        r = proxy.fundrawtransaction(unfunded_tx, options)  # FIXME: handle errors
         funded_tx = r['tx']
 
         logging.debug("Call signrawtransactionwithwallet %s", funded_tx.serialize().hex())

--- a/otsclient/cmds.py
+++ b/otsclient/cmds.py
@@ -45,7 +45,7 @@ def remote_calendar(calendar_uri):
                                                   user_agent="OpenTimestamps-Client/%s" % otsclient.__version__)
 
 
-def create_timestamp(timestamp, calendar_urls, args):
+def create_timestamp(timestamp, nonce, calendar_urls, args):
     """Create a timestamp
 
     calendar_urls - List of calendar's to use
@@ -57,26 +57,34 @@ def create_timestamp(timestamp, calendar_urls, args):
     if setup_bitcoin:
         proxy = setup_bitcoin()
 
-        logging.debug("Call fundrawtransaction for OP_RETURN %s", timestamp.msg.hex())
-        unfunded_tx = CTransaction([], [CTxOut(0, CScript([OP_RETURN, timestamp.msg]))])
+        txid = None
+        if args.txid is not None:
+            logging.debug("Continue with existing transaction")
+            txid = bytes.fromhex(args.txid)[::-1]
+        else:
+            logging.debug("Call fundrawtransaction for OP_RETURN %s", timestamp.msg.hex())
+            unfunded_tx = CTransaction([], [CTxOut(0, CScript([OP_RETURN, timestamp.msg]))])
 
-        options = {}
-        if args.fee_rate is not None:
-            options['fee_rate'] = args.fee_rate
+            options = {}
+            if args.fee_rate is not None:
+                options['fee_rate'] = args.fee_rate
 
-        r = proxy.fundrawtransaction(unfunded_tx, options)  # FIXME: handle errors
-        funded_tx = r['tx']
+            r = proxy.fundrawtransaction(unfunded_tx, options)  # FIXME: handle errors
+            funded_tx = r['tx']
 
-        logging.debug("Call signrawtransactionwithwallet %s", funded_tx.serialize().hex())
-        r = proxy.signrawtransactionwithwallet(funded_tx)
-        assert r['complete']
-        signed_tx = r['tx']
+            logging.debug("Call signrawtransactionwithwallet %s", funded_tx.serialize().hex())
+            r = proxy.signrawtransactionwithwallet(funded_tx)
+            assert r['complete']
+            signed_tx = r['tx']
 
-        logging.debug("Call sendrawtransaction %s", signed_tx.serialize().hex())
-        txid = proxy.sendrawtransaction(signed_tx)
-        logging.info('Sent timestamp tx')
+            logging.debug("Call sendrawtransaction %s", signed_tx.serialize().hex())
+            txid = proxy.sendrawtransaction(signed_tx)
+            logging.info('Sent timestamp tx')
 
         blockhash = None
+
+        logging.info('Waiting for confirmation. This can be interupted and resumed with:\nots stamp --nonce=%s --txid=%s', nonce.hex(), txid[::-1].hex())
+
         while blockhash is None:
             logging.info('Waiting for timestamp tx %s to confirm...' % b2lx(txid))
             time.sleep(1)
@@ -153,6 +161,9 @@ def submit_async(calendar_url, msg, q, timeout):
 
 
 def stamp_command(args):
+    if args.nonce is not None and args.txid is not None:
+        args.use_btc_wallet = True
+
     # Create initial commitment ops for all files
     file_timestamps = []
     merkle_roots = []
@@ -181,7 +192,8 @@ def stamp_command(args):
         # Remember that the files - and their timestamps - might get separated
         # later, so if we didn't use a nonce for every file, the timestamp
         # would leak information on the digests of adjacent files.
-        nonce_appended_stamp = file_timestamp.timestamp.ops.add(OpAppend(os.urandom(16)))
+        nonce = bytes.fromhex(args.nonce) if args.nonce is not None else os.urandom(16)
+        nonce_appended_stamp = file_timestamp.timestamp.ops.add(OpAppend(nonce))
         merkle_root = nonce_appended_stamp.ops.add(OpSHA256())
 
         merkle_roots.append(merkle_root)
@@ -196,7 +208,7 @@ def stamp_command(args):
         args.calendar_urls.append('https://a.pool.eternitywall.com')
         args.calendar_urls.append('https://ots.btc.catallaxy.com')
 
-    create_timestamp(merkle_tip, args.calendar_urls, args)
+    create_timestamp(merkle_tip, nonce, args.calendar_urls, args)
 
     if args.wait:
         upgrade_timestamp(merkle_tip, args)

--- a/otsclient/cmds.py
+++ b/otsclient/cmds.py
@@ -54,8 +54,17 @@ def write_pending(pending_path, nonce, txid_hex):
         logging.info('Wrote recovery file %s' % pending_path)
 
 
+def log_stamp_resume_instruction(nonce, txid_hex):
+    """Log the command to resume solo stamping with the current transaction"""
+    logging.info('ots stamp --nonce=%s --txid=%s', nonce.hex(), txid_hex)
+
+
 def get_waiting_tx_state(proxy, txid, nonce, pending_path=None):
     """Return the txid/blockhash to keep tracking while waiting for confirmation
+
+    Follows wallet-managed RBF replacements using the directional
+    ``replaced_by_txid`` field when available, avoiding switching back to
+    older conflicting transactions listed in ``walletconflicts``.
     """
     r = proxy.gettransaction(txid)
 
@@ -63,6 +72,31 @@ def get_waiting_tx_state(proxy, txid, nonce, pending_path=None):
         # FIXME: this will break when python-bitcoinlib adds RPC
         # support for gettransaction, due to formatting differences
         return txid, lx(r['blockhash'])
+
+    replacement_txid_hex = r.get('replaced_by_txid')
+    if replacement_txid_hex is not None:
+        replacement_txid = lx(replacement_txid_hex)
+        replacement = proxy.gettransaction(replacement_txid)
+
+        if 'blockhash' in replacement:
+            logging.info('Tx was replaced (RBF) by confirmed tx %s' % replacement_txid_hex)
+            return replacement_txid, lx(replacement['blockhash'])
+
+        logging.info('Tx was replaced (RBF). Now tracking replacement tx %s' % replacement_txid_hex)
+        logging.info('To resume manually:')
+        log_stamp_resume_instruction(nonce, replacement_txid_hex)
+        write_pending(pending_path, nonce, replacement_txid_hex)
+        return replacement_txid, None
+
+    for conflict_txid_hex in r.get('walletconflicts', []):
+        try:
+            conflict = proxy.gettransaction(lx(conflict_txid_hex))
+        except Exception:
+            continue
+
+        if 'blockhash' in conflict:
+            logging.info('Tx conflicts with confirmed tx %s' % conflict_txid_hex)
+            return lx(conflict_txid_hex), lx(conflict['blockhash'])
 
     return txid, None
 
@@ -107,7 +141,8 @@ def create_timestamp(timestamp, nonce, calendar_urls, args, pending_path=None):
 
         blockhash = None
 
-        logging.info('Waiting for confirmation. This can be interupted and resumed with:\nots stamp --nonce=%s --txid=%s', nonce.hex(), txid[::-1].hex())
+        logging.info('Waiting for confirmation. This can be interupted and resumed with:')
+        log_stamp_resume_instruction(nonce, txid[::-1].hex())
 
         while blockhash is None:
             logging.info('Waiting for timestamp tx %s to confirm...' % b2lx(txid))

--- a/otsclient/cmds.py
+++ b/otsclient/cmds.py
@@ -54,6 +54,19 @@ def write_pending(pending_path, nonce, txid_hex):
         logging.info('Wrote recovery file %s' % pending_path)
 
 
+def get_waiting_tx_state(proxy, txid, nonce, pending_path=None):
+    """Return the txid/blockhash to keep tracking while waiting for confirmation
+    """
+    r = proxy.gettransaction(txid)
+
+    if 'blockhash' in r:
+        # FIXME: this will break when python-bitcoinlib adds RPC
+        # support for gettransaction, due to formatting differences
+        return txid, lx(r['blockhash'])
+
+    return txid, None
+
+
 def create_timestamp(timestamp, nonce, calendar_urls, args, pending_path=None):
     """Create a timestamp
 
@@ -100,12 +113,7 @@ def create_timestamp(timestamp, nonce, calendar_urls, args, pending_path=None):
             logging.info('Waiting for timestamp tx %s to confirm...' % b2lx(txid))
             time.sleep(1)
 
-            r = proxy.gettransaction(txid)
-
-            if 'blockhash' in r:
-                # FIXME: this will break when python-bitcoinlib adds RPC
-                # support for gettransaction, due to formatting differences
-                blockhash = lx(r['blockhash'])
+            txid, blockhash = get_waiting_tx_state(proxy, txid, nonce, pending_path)
 
         logging.info('Confirmed by block %s' % b2lx(blockhash))
 

--- a/otsclient/cmds.py
+++ b/otsclient/cmds.py
@@ -14,6 +14,7 @@ import sys
 import argparse
 import binascii
 import io
+import json
 import logging
 import os
 import time
@@ -45,7 +46,15 @@ def remote_calendar(calendar_uri):
                                                   user_agent="OpenTimestamps-Client/%s" % otsclient.__version__)
 
 
-def create_timestamp(timestamp, nonce, calendar_urls, args):
+def write_pending(pending_path, nonce, txid_hex):
+    """Write or update the recovery file for interrupted solo stamps"""
+    if pending_path is not None:
+        with open(pending_path, 'w') as f:
+            json.dump({'nonce': nonce.hex(), 'txid': txid_hex}, f)
+        logging.info('Wrote recovery file %s' % pending_path)
+
+
+def create_timestamp(timestamp, nonce, calendar_urls, args, pending_path=None):
     """Create a timestamp
 
     calendar_urls - List of calendar's to use
@@ -80,6 +89,8 @@ def create_timestamp(timestamp, nonce, calendar_urls, args):
             logging.debug("Call sendrawtransaction %s", signed_tx.serialize().hex())
             txid = proxy.sendrawtransaction(signed_tx)
             logging.info('Sent timestamp tx')
+
+            write_pending(pending_path, nonce, txid[::-1].hex())
 
         blockhash = None
 
@@ -171,6 +182,7 @@ def stamp_command(args):
     # Create initial commitment ops for all files
     file_timestamps = []
     merkle_roots = []
+    pending_paths = []
     if not args.files:
         args.files = [sys.stdin.buffer]
 
@@ -196,7 +208,20 @@ def stamp_command(args):
         # Remember that the files - and their timestamps - might get separated
         # later, so if we didn't use a nonce for every file, the timestamp
         # would leak information on the digests of adjacent files.
-        nonce = bytes.fromhex(args.nonce) if args.nonce is not None else os.urandom(16)
+        pending_path = fd.name + '.ots.pending' if fd != sys.stdin.buffer else None
+        if args.nonce is not None:
+            nonce = bytes.fromhex(args.nonce)
+        elif pending_path is not None and os.path.exists(pending_path):
+            with open(pending_path, 'r') as pf:
+                pending = json.load(pf)
+            logging.info('Resuming from recovery file %s' % pending_path)
+            args.nonce = pending['nonce']
+            args.txid = pending['txid']
+            args.use_btc_wallet = True
+            nonce = bytes.fromhex(pending['nonce'])
+        else:
+            nonce = os.urandom(16)
+        pending_paths.append(pending_path)
         nonce_appended_stamp = file_timestamp.timestamp.ops.add(OpAppend(nonce))
         merkle_root = nonce_appended_stamp.ops.add(OpSHA256())
 
@@ -212,7 +237,8 @@ def stamp_command(args):
         args.calendar_urls.append('https://a.pool.eternitywall.com')
         args.calendar_urls.append('https://ots.btc.catallaxy.com')
 
-    create_timestamp(merkle_tip, nonce, args.calendar_urls, args)
+    create_timestamp(merkle_tip, nonce, args.calendar_urls, args,
+                     pending_path=pending_paths[0] if pending_paths else None)
 
     if args.wait:
         upgrade_timestamp(merkle_tip, args)
@@ -231,6 +257,11 @@ def stamp_command(args):
         except IOError as exp:
             logging.error("Failed to create timestamp %r: %s" % (timestamp_file_path, exp))
             sys.exit(1)
+
+    for pending_path in pending_paths:
+        if pending_path is not None and os.path.exists(pending_path):
+            os.remove(pending_path)
+            logging.info('Removed recovery file %s' % pending_path)
 
 def is_timestamp_complete(stamp, args):
     """Determine if timestamp is complete and can be verified"""

--- a/otsclient/cmds.py
+++ b/otsclient/cmds.py
@@ -108,6 +108,10 @@ def create_timestamp(timestamp, nonce, calendar_urls, args):
         assert block_timestamp is not None
         timestamp.merge(block_timestamp)
 
+    # Do not use calendars when solo stamping:
+    if args.use_btc_wallet:
+        return True
+
     m = args.m
     n = len(calendar_urls)
     if m > n or m <= 0:
@@ -201,7 +205,7 @@ def stamp_command(args):
 
     merkle_tip = make_merkle_tree(merkle_roots)
 
-    if not args.calendar_urls:
+    if not args.use_btc_wallet or not args.calendar_urls:
         # Neither calendar nor wallet specified; add defaults
         args.calendar_urls.append('https://a.pool.opentimestamps.org')
         args.calendar_urls.append('https://b.pool.opentimestamps.org')

--- a/otsclient/tests/test_cmds.py
+++ b/otsclient/tests/test_cmds.py
@@ -1,0 +1,33 @@
+import unittest
+
+from bitcoin.core import lx
+
+from otsclient.cmds import get_waiting_tx_state
+
+
+class FakeProxy(object):
+
+    def __init__(self, responses):
+        self.responses = responses
+
+    def gettransaction(self, txid):
+        return self.responses[txid]
+
+
+class TestCmds(unittest.TestCase):
+
+    def test_get_waiting_tx_state_returns_confirmed_tx(self):
+        txid_hex = 'b663f1072fbb53cc4d986435a4d822df7a866ff44d8bcb0e9c2dd6bc212e776e'
+        blockhash_hex = '11' * 32
+        nonce = bytes.fromhex('a373af151062343e242b3e734dd77d0e')
+
+        proxy = FakeProxy({
+            lx(txid_hex): {
+                'confirmations': 1,
+                'blockhash': blockhash_hex,
+            },
+        })
+
+        txid, blockhash = get_waiting_tx_state(proxy, lx(txid_hex), nonce)
+        self.assertEqual(txid, lx(txid_hex))
+        self.assertEqual(blockhash, lx(blockhash_hex))

--- a/otsclient/tests/test_cmds.py
+++ b/otsclient/tests/test_cmds.py
@@ -1,3 +1,5 @@
+import json
+import tempfile
 import unittest
 
 from bitcoin.core import lx
@@ -30,4 +32,61 @@ class TestCmds(unittest.TestCase):
 
         txid, blockhash = get_waiting_tx_state(proxy, lx(txid_hex), nonce)
         self.assertEqual(txid, lx(txid_hex))
+        self.assertEqual(blockhash, lx(blockhash_hex))
+
+    def test_get_waiting_tx_state_tracks_directional_replacement(self):
+        old_txid_hex = '00aa848f0e6a36deb38ed180391cc079ed75a2986ad90c152e628646b6842512'
+        new_txid_hex = 'b663f1072fbb53cc4d986435a4d822df7a866ff44d8bcb0e9c2dd6bc212e776e'
+        nonce = bytes.fromhex('a373af151062343e242b3e734dd77d0e')
+
+        proxy = FakeProxy({
+            lx(old_txid_hex): {
+                'confirmations': 0,
+                'walletconflicts': [new_txid_hex],
+                'replaced_by_txid': new_txid_hex,
+            },
+            lx(new_txid_hex): {
+                'confirmations': 0,
+                'walletconflicts': [old_txid_hex],
+                'replaces_txid': old_txid_hex,
+            },
+        })
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            pending_path = temp_dir + '/stamp.ots.pending'
+
+            txid, blockhash = get_waiting_tx_state(proxy, lx(old_txid_hex), nonce, pending_path)
+            self.assertEqual(txid, lx(new_txid_hex))
+            self.assertIsNone(blockhash)
+
+            with open(pending_path, 'r') as f:
+                pending = json.load(f)
+            self.assertEqual(pending, {'nonce': nonce.hex(), 'txid': new_txid_hex})
+
+            txid, blockhash = get_waiting_tx_state(proxy, txid, nonce, pending_path)
+            self.assertEqual(txid, lx(new_txid_hex))
+            self.assertIsNone(blockhash)
+
+    def test_get_waiting_tx_state_tracks_confirmed_replacement(self):
+        old_txid_hex = '00aa848f0e6a36deb38ed180391cc079ed75a2986ad90c152e628646b6842512'
+        new_txid_hex = 'b663f1072fbb53cc4d986435a4d822df7a866ff44d8bcb0e9c2dd6bc212e776e'
+        blockhash_hex = '11' * 32
+        nonce = bytes.fromhex('a373af151062343e242b3e734dd77d0e')
+
+        proxy = FakeProxy({
+            lx(old_txid_hex): {
+                'confirmations': -1,
+                'walletconflicts': [new_txid_hex],
+                'replaced_by_txid': new_txid_hex,
+            },
+            lx(new_txid_hex): {
+                'confirmations': 1,
+                'walletconflicts': [old_txid_hex],
+                'replaces_txid': old_txid_hex,
+                'blockhash': blockhash_hex,
+            },
+        })
+
+        txid, blockhash = get_waiting_tx_state(proxy, lx(old_txid_hex), nonce)
+        self.assertEqual(txid, lx(new_txid_hex))
         self.assertEqual(blockhash, lx(blockhash_hex))


### PR DESCRIPTION
Currently trying to stamp with `--btc-wallet` will fail for two reasons:

1. the `signrawtransaction` RPC has been deprecated for years
2. it insists on at least two calendars also accepting the transaction

This PR switches to the replacement `signrawtransactionwithwallet` RPC. It also skips using the calendars when using `--btc-wallet`.

In addition it adds a `--fee-rate` argument so you're not dependent on whatever Bitcoin Core decides.

In case the process fails mid way _after_ broadcasting a transaction, as it did before this PR, there's now a way to resume by passing a `--nonce` and `--txid` argument. This has the nice benefit of also making RBF possible.

Finally it documents in the README that this functionality exists, but with a warning.

Unrelated, it also adds a `--btc-signet` option, though at least for stamping `--btc-testnet` works fine with signet.

Fixes #139 and #140.