### PR TITLE
Fix wrapper for worktrees

### DIFF
--- a/otsclient/git_gpg_wrapper.py
+++ b/otsclient/git_gpg_wrapper.py
@@ -107,7 +107,7 @@ def main():
             minor_version = 1
 
             # CWD will be the git repo, so this should get us the right one
-            repo = git.Repo()
+            repo = git.Repo(".")
 
             hextree_start = None
             if git_commit.startswith(b'tree '):


### PR DESCRIPTION
git.Repo's auto detection of the git directory gets confused by the GIT_DIR env var being set when in a worktree, which git appears to do when calling the wrapper. By setting the path to the current directory with `.`, the Repo constructs without issues and works within worktrees.

Fixes #87 