### PR TITLE
Add optional machine-readable output for ots info / ots verify

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,76 @@ For `verify --json`, the exit codes are:
 - `2` for pending / not yet complete
 - `1` for hard verification failure
 
+Machine-readable JSON output is also available for `info`.
+Abbreviated example output:
+
+    $ ots info --json examples/two-calendars.txt.ots
+    {
+      "command": "info",
+      "file": "examples/two-calendars.txt.ots",
+      "file_digest": "efaa174f68e59705757460f4f7d204bd2b535cfd194d9d945418732129404ddb",
+      "hash_algorithm": "sha256",
+      "timestamp": {
+        "attestation_count": 2,
+        "attestations": [
+          {
+            "calendar": "https://alice.btc.calendar.opentimestamps.org",
+            "commitment": "74558d68b166ddea5d752316f399a0d35932a1cd7d8d9823e5738d17b28b3304f2b1774c33c2d8fd1565d457",
+            "status": "pending",
+            "type": "PendingAttestation"
+          },
+          {
+            "calendar": "https://bob.btc.calendar.opentimestamps.org",
+            "commitment": "970a271bea907b64f5e087f3ba1c4d61b8a1697cc8033a48969c976251ea284858c1573b3bace9761665d457",
+            "status": "pending",
+            "type": "PendingAttestation"
+          }
+        ]
+      },
+      "tree": "append 839037eef449dec6..."
+    }
+
+Likewise, `verify` can emit structured status output.
+Abbreviated example output:
+
+    $ ots --no-bitcoin verify --json examples/incomplete.txt.ots
+    {
+      "digest": "05c4f616a8e5310d19d938cfd769864d7f4ccdc2ca8b479b10af83564b097af9",
+      "command": "verify",
+      "hash_algorithm": "sha256",
+      "status": "pending",
+      "verified": false,
+      "exit_code": 2,
+      "target": {
+        "type": "file",
+        "value": "examples/incomplete.txt"
+      },
+      "timestamp_file": "examples/incomplete.txt.ots",
+      "upgraded": true,
+      "attestations": [
+        {
+          "chain": "bitcoin",
+          "commitment": "078cdde9c89f2e3c58c96b1658627fd9298c63c6618954ea24ac3b5a13fe18da",
+          "height": 428648,
+          "reason": "bitcoin_disabled",
+          "status": "manual_check_required",
+          "type": "BitcoinBlockHeaderAttestation"
+        },
+        {
+          "calendar": "https://alice.btc.calendar.opentimestamps.org",
+          "commitment": "e7b04e4e8dacb16fc612d79ec7a61f3f1c73c6d4308f67c1fcd80881c539e4bc9535e8d99bdf1667c4a5cf57",
+          "status": "pending",
+          "type": "PendingAttestation"
+        }
+      ]
+    }
+
+For `verify --json`, the exit codes are:
+
+- `0` for verified
+- `2` for pending / not yet complete
+- `1` for hard verification failure
+
 ### Timestamping and Verifying PGP Signed Git Commits
 
 See `doc/git-integration.md`

--- a/README.md
+++ b/README.md
@@ -105,6 +105,61 @@ commitment operations and attestations in it:
         append 647b90ea1b270a97
         verify PendingAttestation('https://bob.btc.calendar.opentimestamps.org')
 
+Machine-readable JSON output is also available for `info`:
+
+    $ ots info --json examples/two-calendars.txt.ots
+    {
+      "command": "info",
+      "file": "examples/two-calendars.txt.ots",
+      "file_digest": "efaa174f68e59705757460f4f7d204bd2b535cfd194d9d945418732129404ddb",
+      "hash_algorithm": "sha256",
+      "timestamp": {
+        "attestation_count": 2,
+        "attestations": [
+          {
+            "calendar": "https://alice.btc.calendar.opentimestamps.org",
+            "status": "pending",
+            "type": "PendingAttestation"
+          },
+          {
+            "calendar": "https://bob.btc.calendar.opentimestamps.org",
+            "status": "pending",
+            "type": "PendingAttestation"
+          }
+        ]
+      }
+    }
+
+Likewise, `verify` can emit structured status output:
+
+    $ ots --no-bitcoin verify --json examples/incomplete.txt.ots
+    {
+      "command": "verify",
+      "status": "pending",
+      "verified": false,
+      "exit_code": 2,
+      "attestations": [
+        {
+          "chain": "bitcoin",
+          "height": 428648,
+          "reason": "bitcoin_disabled",
+          "status": "manual_check_required",
+          "type": "BitcoinBlockHeaderAttestation"
+        },
+        {
+          "calendar": "https://alice.btc.calendar.opentimestamps.org",
+          "status": "pending",
+          "type": "PendingAttestation"
+        }
+      ]
+    }
+
+For `verify --json`, the exit codes are:
+
+- `0` for verified
+- `2` for pending / not yet complete
+- `1` for hard verification failure
+
 ### Timestamping and Verifying PGP Signed Git Commits
 
 See `doc/git-integration.md`

--- a/otsclient/args.py
+++ b/otsclient/args.py
@@ -207,12 +207,16 @@ def parse_ots_args(raw_args):
 
     parser_verify.add_argument('timestamp_fd', metavar='TIMESTAMP', type=argparse.FileType('rb'),
                                help='Timestamp filename')
+    parser_verify.add_argument('--json', dest='json', action='store_true', default=False,
+                               help='Emit machine-readable JSON output')
 
     # ----- info -----
     parser_info = subparsers.add_parser('info', aliases=['i'],
                                         help='Show information on a timestamp')
     parser_info.add_argument('file', metavar='FILE', type=argparse.FileType('rb'),
                              help='Filename')
+    parser_info.add_argument('--json', dest='json', action='store_true', default=False,
+                             help='Emit machine-readable JSON output')
 
     # ----- prune -----
     parser_prune = subparsers.add_parser('prune', aliases=['p'],

--- a/otsclient/cmds.py
+++ b/otsclient/cmds.py
@@ -10,6 +10,8 @@
 # in the LICENSE file.
 
 import sys
+import json
+import contextlib
 
 import argparse
 import binascii
@@ -38,6 +40,153 @@ from opentimestamps.bitcoin import *
 import opentimestamps.calendar
 
 import otsclient
+
+EXIT_VERIFY_FAILED = 1
+EXIT_VERIFY_PENDING = 2
+
+
+@contextlib.contextmanager
+def _suppress_logging():
+    previous = logging.root.manager.disable
+    logging.disable(logging.CRITICAL)
+    try:
+        yield
+    finally:
+        logging.disable(previous)
+
+
+def _attestation_type_name(attestation):
+    return attestation.__class__.__name__
+
+
+def _serialize_attestation(msg, attestation):
+    item = {
+        "type": _attestation_type_name(attestation),
+        "commitment": b2lx(msg),
+    }
+    if isinstance(attestation, PendingAttestation):
+        item["status"] = "pending"
+        item["calendar"] = attestation.uri
+    elif isinstance(attestation, BitcoinBlockHeaderAttestation):
+        item["status"] = "attested"
+        item["chain"] = "bitcoin"
+        item["height"] = attestation.height
+    elif isinstance(attestation, LitecoinBlockHeaderAttestation):
+        item["status"] = "attested"
+        item["chain"] = "litecoin"
+        item["height"] = attestation.height
+    elif isinstance(attestation, UnknownAttestation):
+        item["status"] = "unknown"
+        item["tag"] = b2x(attestation.TAG)
+        item["payload"] = b2x(attestation.payload)
+    else:
+        item["status"] = "unknown"
+    return item
+
+
+def timestamp_to_json(timestamp):
+    items = [_serialize_attestation(msg, attestation)
+             for msg, attestation in timestamp.all_attestations()]
+    return {
+        "attestation_count": len(items),
+        "attestations": items,
+    }
+
+
+def detached_timestamp_to_json(detached_timestamp, verbosity=0):
+    return {
+        "hash_algorithm": detached_timestamp.file_hash_op.HASHLIB_NAME,
+        "file_digest": b2x(detached_timestamp.file_digest),
+        "timestamp": timestamp_to_json(detached_timestamp.timestamp),
+        "tree": detached_timestamp.timestamp.str_tree(verbosity=verbosity),
+    }
+
+
+def verify_timestamp_json(timestamp, args):
+    args.calendar_urls = []
+    with _suppress_logging():
+        upgrade_timestamp(timestamp, args)
+
+    result = {
+        "status": "failed",
+        "verified": False,
+        "upgraded": True,
+        "attestations": [],
+    }
+
+    def attestation_key(item):
+        (msg, attestation) = item
+        if attestation.__class__ == BitcoinBlockHeaderAttestation:
+            return attestation.height
+        else:
+            return 2**32-1
+
+    for msg, attestation in sorted(timestamp.all_attestations(), key=attestation_key):
+        entry = _serialize_attestation(msg, attestation)
+
+        if isinstance(attestation, PendingAttestation):
+            entry["status"] = "pending"
+            result["attestations"].append(entry)
+            continue
+
+        if isinstance(attestation, BitcoinBlockHeaderAttestation):
+            if not args.use_bitcoin:
+                entry["status"] = "manual_check_required"
+                entry["reason"] = "bitcoin_disabled"
+                result["attestations"].append(entry)
+                continue
+
+            try:
+                proxy = args.setup_bitcoin()
+            except SystemExit:
+                entry["status"] = "failed"
+                entry["reason"] = "bitcoin_connection_error"
+                result["attestations"].append(entry)
+                continue
+
+            try:
+                block_count = proxy.getblockcount()
+                blockhash = proxy.getblockhash(attestation.height)
+                block_header = proxy.getblockheader(blockhash)
+                attested_time = attestation.verify_against_blockheader(msg, block_header)
+            except IndexError:
+                entry["status"] = "pending"
+                entry["reason"] = "block_height_not_found"
+                entry["highest_known_block"] = block_count
+                result["attestations"].append(entry)
+                continue
+            except ConnectionError:
+                entry["status"] = "failed"
+                entry["reason"] = "bitcoin_connection_error"
+                result["attestations"].append(entry)
+                continue
+            except VerificationError as err:
+                entry["status"] = "failed"
+                entry["reason"] = "verification_error"
+                entry["detail"] = str(err)
+                result["attestations"].append(entry)
+                continue
+
+            entry["status"] = "verified"
+            entry["block_hash"] = b2lx(blockhash)
+            entry["attested_time"] = attested_time
+            entry["attested_time_iso"] = time.strftime('%Y-%m-%dT%H:%M:%SZ',
+                                                       time.gmtime(attested_time))
+            result["attestations"].append(entry)
+            result["verified"] = True
+            result["status"] = "verified"
+            break
+
+        else:
+            result["attestations"].append(entry)
+
+    if not result["verified"]:
+        if any(item.get("status") == "pending" for item in result["attestations"]):
+            result["status"] = "pending"
+        elif any(item.get("status") == "manual_check_required" for item in result["attestations"]):
+            result["status"] = "manual_check_required"
+
+    return result
 
 def remote_calendar(calendar_uri):
     """Create a remote calendar with User-Agent set appropriately"""
@@ -487,6 +636,32 @@ def verify_command(args):
             logging.error("File does not match original!")
             sys.exit(1)
 
+    if getattr(args, 'json', False):
+        result = {
+            "command": "verify",
+            "timestamp_file": args.timestamp_fd.name,
+            "target": None,
+            "digest": b2x(detached_timestamp.file_digest),
+            "hash_algorithm": detached_timestamp.file_hash_op.HASHLIB_NAME,
+        }
+
+        if args.hex_digest is not None:
+            result["target"] = {"type": "digest", "value": args.hex_digest.lower()}
+        elif args.target_fd is not None:
+            result["target"] = {"type": "file", "value": args.target_fd.name}
+        else:
+            result["target"] = {"type": "file", "value": args.timestamp_fd.name[:-4]}
+
+        verify_result = verify_timestamp_json(detached_timestamp.timestamp, args)
+        result.update(verify_result)
+        result["exit_code"] = 0 if verify_result["verified"] else (
+            EXIT_VERIFY_PENDING if verify_result["status"] == "pending" else EXIT_VERIFY_FAILED
+        )
+        print(json.dumps(result, indent=2, sort_keys=True))
+        if not verify_result["verified"]:
+            sys.exit(result["exit_code"])
+        return
+
     if not verify_timestamp(detached_timestamp.timestamp, args):
         sys.exit(1)
 
@@ -501,6 +676,15 @@ def info_command(args):
     except DeserializationError as exp:
         logging.error("Invalid timestamp file %r: %s" % (args.file.name, exp))
         sys.exit(1)
+
+    if getattr(args, 'json', False):
+        result = {
+            "command": "info",
+            "file": args.file.name,
+        }
+        result.update(detached_timestamp_to_json(detached_timestamp, verbosity=args.verbosity))
+        print(json.dumps(result, indent=2, sort_keys=True))
+        return
 
     print("File %s hash: %s" % (detached_timestamp.file_hash_op.HASHLIB_NAME, hexlify(detached_timestamp.file_digest).decode('utf8')))
 

--- a/otsclient/cmds.py
+++ b/otsclient/cmds.py
@@ -13,7 +13,6 @@ import sys
 import json
 import contextlib
 
-import argparse
 import binascii
 import io
 import logging
@@ -21,8 +20,6 @@ import os
 import time
 import urllib.request
 import threading
-import bitcoin
-import bitcoin.rpc
 from queue import Queue, Empty
 
 from bitcoin.core import b2x, b2lx, lx, CTxOut, CTransaction
@@ -105,12 +102,12 @@ def detached_timestamp_to_json(detached_timestamp, verbosity=0):
 def verify_timestamp_json(timestamp, args):
     args.calendar_urls = []
     with _suppress_logging():
-        upgrade_timestamp(timestamp, args)
+        changed = upgrade_timestamp(timestamp, args)
 
     result = {
         "status": "failed",
         "verified": False,
-        "upgraded": True,
+        "upgraded": changed,
         "attestations": [],
     }
 
@@ -187,6 +184,7 @@ def verify_timestamp_json(timestamp, args):
             result["status"] = "manual_check_required"
 
     return result
+
 
 def remote_calendar(calendar_uri):
     """Create a remote calendar with User-Agent set appropriately"""
@@ -600,6 +598,8 @@ def verify_command(args):
         logging.error("Invalid timestamp file %r: %s" % (args.timestamp_fd.name, exp))
         sys.exit(1)
 
+    target_value = None
+
     if args.hex_digest is not None:
         try:
             digest = binascii.unhexlify(args.hex_digest.encode('utf8'))
@@ -626,6 +626,7 @@ def verify_command(args):
             except IOError as exp:
                 logging.error('Could not open target: %s' % exp)
                 sys.exit(1)
+        target_value = args.target_fd.name
 
         logging.debug("Hashing file, algorithm %s" % detached_timestamp.file_hash_op.TAG_NAME)
         actual_file_digest = detached_timestamp.file_hash_op.hash_fd(args.target_fd)
@@ -640,22 +641,21 @@ def verify_command(args):
         result = {
             "command": "verify",
             "timestamp_file": args.timestamp_fd.name,
-            "target": None,
             "digest": b2x(detached_timestamp.file_digest),
             "hash_algorithm": detached_timestamp.file_hash_op.HASHLIB_NAME,
         }
 
         if args.hex_digest is not None:
             result["target"] = {"type": "digest", "value": args.hex_digest.lower()}
-        elif args.target_fd is not None:
-            result["target"] = {"type": "file", "value": args.target_fd.name}
         else:
-            result["target"] = {"type": "file", "value": args.timestamp_fd.name[:-4]}
+            result["target"] = {"type": "file", "value": target_value}
 
         verify_result = verify_timestamp_json(detached_timestamp.timestamp, args)
         result.update(verify_result)
         result["exit_code"] = 0 if verify_result["verified"] else (
-            EXIT_VERIFY_PENDING if verify_result["status"] == "pending" else EXIT_VERIFY_FAILED
+            EXIT_VERIFY_PENDING
+            if verify_result["status"] in ("pending", "manual_check_required")
+            else EXIT_VERIFY_FAILED
         )
         print(json.dumps(result, indent=2, sort_keys=True))
         if not verify_result["verified"]:

--- a/otsclient/tests/test_json_output.py
+++ b/otsclient/tests/test_json_output.py
@@ -129,3 +129,29 @@ class TestJsonOutput(unittest.TestCase):
                     cmds.verify_command(args)
 
         self.assertEqual(exc.exception.code, cmds.EXIT_VERIFY_FAILED)
+
+    def test_verify_command_json_exits_manual_check_required_with_code_2(self):
+        t = Timestamp(b"\xaa" * 32)
+        detached = DetachedTimestampFile(_HashOp(), t)
+        timestamp_fd = io.BytesIO(b"")
+        timestamp_fd.name = "dummy.ots"
+        args = _FakeArgs(
+            timestamp_fd=timestamp_fd,
+            hex_digest="aa" * 32,
+            target_fd=None,
+            json=True,
+        )
+
+        with patch("otsclient.cmds.DetachedTimestampFile.deserialize", return_value=detached):
+            with patch(
+                "otsclient.cmds.verify_timestamp_json",
+                return_value={
+                    "status": "manual_check_required",
+                    "verified": False,
+                    "attestations": [],
+                },
+            ):
+                with self.assertRaises(SystemExit) as exc:
+                    cmds.verify_command(args)
+
+        self.assertEqual(exc.exception.code, cmds.EXIT_VERIFY_PENDING)

--- a/otsclient/tests/test_json_output.py
+++ b/otsclient/tests/test_json_output.py
@@ -1,0 +1,131 @@
+import unittest
+import io
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from opentimestamps.core.notary import BitcoinBlockHeaderAttestation, PendingAttestation
+from opentimestamps.core.op import OpAppend
+from opentimestamps.core.timestamp import DetachedTimestampFile, Timestamp
+
+from otsclient import cmds
+
+
+class _HashOp:
+    HASHLIB_NAME = "sha256"
+    DIGEST_LENGTH = 32
+
+
+class _FakeArgs(SimpleNamespace):
+    pass
+
+
+class _FakeProxy:
+    def getblockcount(self):
+        return 900000
+
+    def getblockhash(self, height):
+        return b"\x11" * 32
+
+    def getblockheader(self, blockhash):
+        return {"merkleroot": "00" * 32}
+
+
+class TestJsonOutput(unittest.TestCase):
+    def test_timestamp_to_json_serializes_pending_attestation(self):
+        t = Timestamp(b"\x00" * 32)
+        t.attestations = {PendingAttestation("https://calendar.example")}
+
+        payload = cmds.timestamp_to_json(t)
+
+        self.assertEqual(payload["attestation_count"], 1)
+        self.assertEqual(payload["attestations"][0]["type"], "PendingAttestation")
+        self.assertEqual(payload["attestations"][0]["status"], "pending")
+
+    def test_detached_timestamp_to_json_includes_digest_and_tree(self):
+        t = Timestamp(b"\xaa" * 32)
+        t.ops.add(OpAppend(b"\x01"))
+        detached = DetachedTimestampFile(_HashOp(), t)
+
+        payload = cmds.detached_timestamp_to_json(detached)
+
+        self.assertEqual(payload["hash_algorithm"], "sha256")
+        self.assertEqual(payload["file_digest"], "aa" * 32)
+        self.assertIn("tree", payload)
+
+    def test_verify_timestamp_json_reports_pending(self):
+        t = Timestamp(b"\x00" * 32)
+        t.attestations = {PendingAttestation("https://calendar.example")}
+        args = _FakeArgs(use_bitcoin=False, calendar_urls=[], wait=False)
+
+        with patch("otsclient.cmds.upgrade_timestamp", lambda timestamp, args: None):
+            payload = cmds.verify_timestamp_json(t, args)
+
+        self.assertEqual(payload["status"], "pending")
+        self.assertFalse(payload["verified"])
+
+    def test_verify_timestamp_json_reports_verified_bitcoin_attestation(self):
+        t = Timestamp(b"\x00" * 32)
+        att = BitcoinBlockHeaderAttestation(123)
+        t.attestations = {att}
+        args = _FakeArgs(
+            use_bitcoin=True,
+            calendar_urls=[],
+            wait=False,
+            setup_bitcoin=lambda: _FakeProxy(),
+        )
+
+        with patch("otsclient.cmds.upgrade_timestamp", lambda timestamp, args: None):
+            with patch.object(
+                BitcoinBlockHeaderAttestation,
+                "verify_against_blockheader",
+                lambda self, msg, block_header: 1234567890,
+            ):
+                payload = cmds.verify_timestamp_json(t, args)
+
+        self.assertEqual(payload["status"], "verified")
+        self.assertTrue(payload["verified"])
+        self.assertEqual(payload["attestations"][0]["height"], 123)
+
+    def test_verify_command_json_exits_pending_with_code_2(self):
+        t = Timestamp(b"\xaa" * 32)
+        detached = DetachedTimestampFile(_HashOp(), t)
+        timestamp_fd = io.BytesIO(b"")
+        timestamp_fd.name = "dummy.ots"
+        args = _FakeArgs(
+            timestamp_fd=timestamp_fd,
+            hex_digest="aa" * 32,
+            target_fd=None,
+            json=True,
+        )
+
+        with patch("otsclient.cmds.DetachedTimestampFile.deserialize", return_value=detached):
+            with patch(
+                "otsclient.cmds.verify_timestamp_json",
+                return_value={"status": "pending", "verified": False, "attestations": []},
+            ):
+                with self.assertRaises(SystemExit) as exc:
+                    cmds.verify_command(args)
+
+        self.assertEqual(exc.exception.code, cmds.EXIT_VERIFY_PENDING)
+
+    def test_verify_command_json_exits_failed_with_code_1(self):
+        t = Timestamp(b"\xaa" * 32)
+        detached = DetachedTimestampFile(_HashOp(), t)
+        timestamp_fd = io.BytesIO(b"")
+        timestamp_fd.name = "dummy.ots"
+        args = _FakeArgs(
+            timestamp_fd=timestamp_fd,
+            hex_digest="aa" * 32,
+            target_fd=None,
+            json=True,
+        )
+
+        with patch("otsclient.cmds.DetachedTimestampFile.deserialize", return_value=detached):
+            with patch(
+                "otsclient.cmds.verify_timestamp_json",
+                return_value={"status": "failed", "verified": False, "attestations": []},
+            ):
+                with self.assertRaises(SystemExit) as exc:
+                    cmds.verify_command(args)
+
+        self.assertEqual(exc.exception.code, cmds.EXIT_VERIFY_FAILED)


### PR DESCRIPTION
## Summary

  This PR adds optional machine-readable output for the OpenTimestamps client CLI.

  Initial scope:
  - `ots info --json`
  - `ots verify --json`

  Default human-readable output is unchanged.

  ## Motivation

  Downstream automation currently has to parse human-oriented strings such as:

  - `Pending confirmation in Bitcoin blockchain`
  - `BitcoinBlockHeaderAttestation(...)`
  - `Success! Bitcoin block ...`
  - `Failed! Timestamp not complete`

  That makes integrations brittle and makes it hard to distinguish:

  - incomplete / pending timestamp vs hard verification failure
  - manual-check-required cases (for example `--no-bitcoin`)
  - attested block heights and other useful metadata already visible to the client

  This PR adds a structured interface for those cases without touching the timestamp format or consensus-critical proof
  logic.

  ## Scope

  This PR adds:
  - `ots info --json`
  - `ots verify --json`

  It does **not**:
  - change the OpenTimestamps proof format
  - change attestation validation semantics
  - add block explorer verification
  - change the default text output

  ## Behavior

  ### `ots info --json`

  Outputs structured information about a detached timestamp, including:
  - file hash algorithm
  - file digest
  - tree rendering
  - known attestations

  ### `ots verify --json`

  Outputs structured verification information, including:
  - overall status
  - verification result
  - attestation list
  - target metadata
  - exit code semantics for machine consumers

  For `verify --json`, the exit codes are:
  - `0` = verified
  - `2` = pending / not yet complete
  - `1` = hard verification failure

  This allows downstream tools to distinguish incomplete timestamps from genuinely invalid or failed verification cases.

  ## Design notes

  This change is intentionally implemented in the client CLI layer (`otsclient.args` / `otsclient.cmds`) and does not
  modify `opentimestamps.core`.

  That keeps the feature focused on operability and integration rather than proof semantics.

  ## Why this is useful

  This improves:
  - CI and automation wrappers
  - monitoring / reporting integrations
  - external verifier tooling
  - downstream projects that need to distinguish pending timestamps from hard failure

  ## Tests

  Added tests for:
  - JSON serialization of pending attestations
  - JSON serialization of detached timestamps
  - `verify --json` pending status
  - `verify --json` verified status
  - command-level pending vs failure exit code behavior

  ## Documentation

  README examples were added for:
  - `ots info --json`
  - `ots verify --json`

  ## Related

  This is related to #127, but intentionally narrower.

  This PR does not attempt to solve explorer-backed verification.
  It provides a stable machine-readable CLI surface that makes downstream tooling and future verifier work much easier.