### PR TITLE
Add lite-client support: local Bitcoin header archive for offline verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,23 @@ third-party hosts), `--force` to overwrite an existing archive, and
 `<cache_dir>/headers-<network>.bin`. Sources can be anything urllib
 supports: `http(s)://`, `file://`, etc.
 
+For shipping a self-verifying disclosure bundle -- where the recipient
+should be able to verify a `.ots` offline without an OTS installation
+or network access -- build a *sidecar* archive that covers only the
+Bitcoin block heights the proof attests to:
+
+    $ ots headers fetch MANIFEST.sha256.asc.ots
+    Building sidecar for 1 Bitcoin attestation height(s): 949414
+    Fetching block 949414 header...
+    Done. Wrote sidecar MANIFEST.sha256.asc.ots-btc-headers.bin
+          (network=mainnet, 1 header(s) for heights 949414)
+
+The sidecar is a small file (~100 bytes per attested height) that sits
+next to the `.ots` and contains exactly what's needed to verify it.
+Pass multiple `.ots` files to combine their heights into one sidecar.
+`ots verify --headers <sidecar>.bin <file>.ots` works against either
+dense archives or sparse sidecars.
+
 Inspect a header archive:
 
     $ ots headers info ~/.cache/opentimestamps/ots/headers.bin

--- a/README.md
+++ b/README.md
@@ -11,7 +11,10 @@ files within a Git repository.
 * Python3
 
 While OpenTimestamps can *create* timestamps without a local Bitcoin node, to
-*verify* timestamps you need a local Bitcoin Core node (a pruned node is fine).
+*verify* timestamps you traditionally need a local Bitcoin Core node (a pruned
+node is fine). As of the lite-client support added in `headers.py`, you can
+alternatively verify against a small local archive of Bitcoin block headers
+(~70 MB total for the whole chain) — see "Offline / lite verification" below.
 
 
 ## Installation
@@ -129,6 +132,44 @@ and meaningless digest. Equally, if multiple files are timestamped at once,
 each file is protected by an individual nonce; the timestamp for one file
 reveals nothing about the contents of another file timestamped at the same
 time.
+
+## Offline / lite verification (local header archive)
+
+Bitcoin-anchored OpenTimestamps proofs mathematically resolve to one specific
+Bitcoin block's merkle root. Verifying such a proof traditionally requires a
+local Bitcoin Core node, but at 80 bytes per block the entire chain's headers
+fit in around 70 MB. The `ots headers` subcommand maintains a local archive of
+headers so that verification can run with no Bitcoin node and no network
+access at verify time.
+
+Create or extend a header archive by fetching from public Esplora-compatible
+sources (with cross-source quorum agreement and per-header PoW + chain
+continuity validation at append time):
+
+    $ ots headers fetch --until-height 800000
+    Created header archive .../headers.bin (network=mainnet, start_height=0)
+    Auto-detected chain tip height 875432 (from 3 source(s))
+    Fetching headers 0..800000 from 3 source(s), quorum=2
+    ... fetched 100 headers (at height 100)
+    ... fetched 200 headers (at height 200)
+    ...
+
+Inspect a header archive:
+
+    $ ots headers info ~/.cache/opentimestamps/ots/headers.bin
+    Path:         .../headers.bin
+    Network:      mainnet
+    Header count: 800001
+    Height range: 0..800000
+    File size:    64000016 bytes
+
+Verify an OTS proof against the local archive — no Bitcoin node, no internet:
+
+    $ ots verify --headers .../headers.bin README.md.ots
+    Success! Bitcoin block 800000 attests existence as of 2023-07-24 UTC
+
+The header archive is mutually exclusive with `--bitcoin-node` at verify time.
+Stamping is unaffected - only verification gains the new option.
 
 ## Compatibility Expectations
 

--- a/README.md
+++ b/README.md
@@ -136,15 +136,34 @@ time.
 ## Offline / lite verification (local header archive)
 
 Bitcoin-anchored OpenTimestamps proofs mathematically resolve to one specific
-Bitcoin block's merkle root. Verifying such a proof traditionally requires a
+Bitcoin block's merkle root. Verifying such a proof traditionally required a
 local Bitcoin Core node, but at 80 bytes per block the entire chain's headers
-fit in around 70 MB. The `ots headers` subcommand maintains a local archive of
-headers so that verification can run with no Bitcoin node and no network
-access at verify time.
+fit in around 70 MB.
 
-Create or extend a header archive by fetching from public Esplora-compatible
-sources (with cross-source quorum agreement and per-header PoW + chain
-continuity validation at append time):
+By default, `ots verify` now Just Works without any flags. When neither
+`--bitcoin-node` nor `--headers` is given, it first probes for a reachable
+local Bitcoin Core node and uses it when present (preserving the historical
+"I run `bitcoind`, just use it" UX); otherwise it auto-fetches the headers
+it needs for the attested heights from public Esplora-compatible sources
+with quorum agreement, and caches them locally so subsequent verifications
+of the same proof are network-free:
+
+    $ ots verify README.md.ots
+    Fetching block 875432 header from public sources...
+    Success! Bitcoin block 875432 attests existence as of 2025-12-14 UTC
+
+No Bitcoin node, no `--headers` flag, no preconfiguration required. The trust
+signal is per-header proof-of-work plus quorum across multiple independent
+public sources. An info-level log line ("Using local Bitcoin Core node ..."
+vs "Fetching block N header ...") indicates which path was taken so
+privacy-conscious users see at a glance whether their proof hit a third
+party.
+
+For air-gapped or archival verification, the `ots headers` subcommand
+maintains a local header archive that can populate a full chain (~70 MB)
+once and verify forever offline. Create or extend an archive by fetching
+from public Esplora-compatible sources (with cross-source quorum agreement
+and per-header PoW + chain continuity validation at append time):
 
     $ ots headers fetch --until-height 800000
     Created header archive .../headers.bin (network=mainnet, start_height=0)
@@ -179,13 +198,14 @@ Inspect a header archive:
     Height range: 0..800000
     File size:    64000016 bytes
 
-Verify an OTS proof against the local archive — no Bitcoin node, no internet:
+Verify an OTS proof against the local archive — no Bitcoin node, no internet,
+no public fetch:
 
     $ ots verify --headers .../headers.bin README.md.ots
     Success! Bitcoin block 800000 attests existence as of 2023-07-24 UTC
 
-The header archive is mutually exclusive with `--bitcoin-node` at verify time.
-Stamping is unaffected - only verification gains the new option.
+`--headers` and `--bitcoin-node` are mutually exclusive at verify time, and
+each takes precedence over the default auto-fetch. Stamping is unaffected.
 
 ## Compatibility Expectations
 

--- a/README.md
+++ b/README.md
@@ -154,6 +154,22 @@ continuity validation at append time):
     ... fetched 200 headers (at height 200)
     ...
 
+For bulk fetches like populating from genesis, the `--p2p` flag uses
+Bitcoin's native getheaders protocol instead of per-header HTTP, returning
+up to 2000 headers per round trip. DNS seeds are used for peer discovery
+by default; `--p2p-peer host[:port]` overrides this:
+
+    $ ots headers fetch --p2p
+    Fetching headers via Bitcoin P2P to the chain tip
+    ... fetched 5000 headers (at height 5000)
+    ... fetched 10000 headers (at height 10000)
+    ...
+    Done. Appended 875433 header(s); archive now covers 0..875432
+
+Re-running `ots headers fetch` against an existing archive appends from
+where the last fetch left off; you can keep an evergreen archive by
+running it periodically.
+
 Inspect a header archive:
 
     $ ots headers info ~/.cache/opentimestamps/ots/headers.bin

--- a/README.md
+++ b/README.md
@@ -189,6 +189,26 @@ Re-running `ots headers fetch` against an existing archive appends from
 where the last fetch left off; you can keep an evergreen archive by
 running it periodically.
 
+To skip the fetch entirely, download a prebuilt archive from a URL with
+`ots headers bootstrap`. The downloaded file is validated end-to-end
+(PoW + prev-hash continuity for every header) before install, so the
+URL host doesn't need to be trusted -- math is the trust signal:
+
+    $ ots headers bootstrap https://example.com/headers-mainnet.bin
+    Downloading header archive from https://example.com/headers-mainnet.bin
+    ... downloaded 10 MB
+    ... downloaded 20 MB
+    ...
+    Validating archive (PoW + chain continuity, every header)...
+    Validated 949588 header(s) (heights 0..949587)
+    Installed archive at .../headers-mainnet.bin
+
+Pass `--sha256 HEX` to add an integrity precheck (recommended for
+third-party hosts), `--force` to overwrite an existing archive, and
+`--output PATH` to install somewhere other than the default
+`<cache_dir>/headers-<network>.bin`. Sources can be anything urllib
+supports: `http(s)://`, `file://`, etc.
+
 Inspect a header archive:
 
     $ ots headers info ~/.cache/opentimestamps/ots/headers.bin

--- a/TODO.md
+++ b/TODO.md
@@ -13,12 +13,6 @@ Should be able to specify a digest to timestamp, rather than being limited to
 timestamping files.
 
 
-## Lite-Client Support
-
-Probably best to add a way to get headers from calendar servers + other
-sources, then check PoW. Also need to improve docs re: using a pruned node.
-
-
 ## Pruned Node Explanation
 
 Explain requirements for running a pruned Bitcoin node - it's really not as big

--- a/otsclient/args.py
+++ b/otsclient/args.py
@@ -272,6 +272,15 @@ def parse_ots_args(raw_args):
     parser_headers_fetch.add_argument('--quorum', dest='quorum', type=int, default=None,
                                       help='Minimum number of agreeing sources required per header. '
                                            'Default: majority of provided sources (rounded up).')
+    parser_headers_fetch.add_argument('--p2p', dest='use_p2p', action='store_true', default=False,
+                                      help='Fetch via the Bitcoin P2P getheaders protocol instead of '
+                                           'HTTP block explorers. Much faster for bulk fetches '
+                                           '(up to 2000 headers per round trip). Uses DNS seeds for '
+                                           'peer discovery by default. Mutually exclusive with --source.')
+    parser_headers_fetch.add_argument('--p2p-peer', metavar='HOST[:PORT]', dest='p2p_peers',
+                                      action='append', type=str, default=[],
+                                      help='Specific Bitcoin P2P peer to connect to (may be repeated). '
+                                           'Implies --p2p.')
     parser_headers_fetch.set_defaults(cmd_func=otsclient.cmds.headers_fetch_command)
 
     parser_headers_info = headers_subparsers.add_parser('info',

--- a/otsclient/args.py
+++ b/otsclient/args.py
@@ -76,8 +76,9 @@ def make_common_options_arg_parser():
                               "Format: domain[:port] (e.g. localhost:9050)")
 
     parser.add_argument("--bitcoin-node", dest="bitcoin_node", type=str,
-                        help="Bitcoin node URL to connect to (defaults to local "
-                             "configuration)")
+                        help="Bitcoin node URL to connect to. When set, verify "
+                             "fetches block headers from this node instead of "
+                             "auto-fetching from public block-explorer sources.")
 
     return parser
 
@@ -151,11 +152,47 @@ def handle_common_options(args, parser):
 
     args.setup_bitcoin = setup_bitcoin
 
+    def _try_local_bitcoin_node():
+        """Probe for a reachable local Bitcoin Core node.
+
+        Returns a connected RPC proxy on success, or None if no local
+        node is reachable. Bounded by a short timeout so it doesn't
+        block verify when no node is running. Used by get_header_source
+        to preserve the historical "I have a local node, just use it"
+        behavior without requiring the user to pass --bitcoin-node.
+        """
+        if args.btc_net == 'testnet':
+            bitcoin.SelectParams('testnet')
+        elif args.btc_net == 'regtest':
+            bitcoin.SelectParams('regtest')
+        elif args.btc_net == 'mainnet':
+            bitcoin.SelectParams('mainnet')
+        else:
+            assert False
+        try:
+            proxy = bitcoin.rpc.Proxy(service_url=None, timeout=2)
+            proxy.getblockcount()  # cheap call to confirm reachability + auth
+        except Exception as exp:
+            logging.debug("No reachable local Bitcoin node: %s" % exp)
+            return None
+        return proxy
+
     def get_header_source():
         """Return a BlockHeaderSource appropriate for the current args.
 
-        If --headers was given to the verify subcommand, use a local
-        archive. Otherwise fall back to the existing Bitcoin RPC proxy.
+        Precedence:
+          1. --headers PATH         -> LocalArchiveHeaderSource
+          2. --bitcoin-node URL     -> BitcoinNodeHeaderSource
+          3. (default, no flags)    -> If a local Bitcoin Core node is
+                                       reachable, use it (preserves the
+                                       historical no-flag behavior for
+                                       node operators). Otherwise
+                                       AutoFetchHeaderSource (lazy HTTP
+                                       fetch with quorum, cached in
+                                       <cache_dir>/verify-cache-<net>.bin).
+
+        Networks without default public sources (regtest) only have the
+        Bitcoin-node path available in case 3.
         """
         headers_path = getattr(args, 'headers_path', None)
         if headers_path is not None:
@@ -175,8 +212,48 @@ def handle_common_options(args, parser):
                 sys.exit(1)
             return otsclient.headers.LocalArchiveHeaderSource(archive)
 
-        proxy = setup_bitcoin()
-        return otsclient.headers.BitcoinNodeHeaderSource(proxy)
+        if args.bitcoin_node is not None:
+            proxy = setup_bitcoin()
+            return otsclient.headers.BitcoinNodeHeaderSource(proxy)
+
+        # Default: prefer a reachable local node (preserves historical
+        # behavior for users who run `bitcoind`), else auto-fetch from
+        # public Esplora-compatible sources with quorum and on-disk
+        # caching.
+        sources = otsclient.headers.make_default_esplora_sources(args.btc_net)
+        if not sources:
+            # No public sources for this network (e.g., regtest, which
+            # has no public peers, DNS seeds, or block explorers by
+            # design). Bitcoin node is the only path; let setup_bitcoin
+            # produce its own clear error if no node is reachable.
+            logging.info(
+                "Network is %s; no public block-explorer sources available, "
+                "falling back to Bitcoin node "
+                "(use --headers PATH for fully offline verification)" % args.btc_net)
+            proxy = setup_bitcoin()
+            return otsclient.headers.BitcoinNodeHeaderSource(proxy)
+
+        local_proxy = _try_local_bitcoin_node()
+        if local_proxy is not None:
+            logging.info(
+                "Using local Bitcoin Core node for header lookup "
+                "(pass --bitcoin-node URL to override, or use --headers PATH "
+                "for an air-gapped archive)")
+            return otsclient.headers.BitcoinNodeHeaderSource(local_proxy)
+
+        if args.cache_path is None:
+            # User passed --no-cache; disable verify-cache too.
+            cache = None
+        else:
+            # One cache file per network so mainnet and testnet proofs
+            # don't collide on the same path.
+            cache_filename = 'verify-cache-%s.bin' % args.btc_net
+            cache_path = os.path.join(args.cache_path, cache_filename)
+            cache = otsclient.headers.VerifyCache(cache_path)
+
+        fetcher = otsclient.headers.HeaderFetcher(sources)
+        return otsclient.headers.AutoFetchHeaderSource(
+            cache, fetcher, args.btc_net)
 
     args.get_header_source = get_header_source
 
@@ -238,8 +315,9 @@ def parse_ots_args(raw_args):
     parser_verify.add_argument('--headers', metavar='PATH', dest='headers_path', type=str,
                                default=None,
                                help='Verify using a local Bitcoin header archive (produced by '
-                                    '`ots headers fetch`) instead of a local Bitcoin node. '
-                                    'Enables fully offline verification.')
+                                    '`ots headers fetch`) instead of the default auto-fetch. '
+                                    'Enables fully offline verification when the archive covers '
+                                    'the attested block heights.')
 
     parser_verify.add_argument('timestamp_fd', metavar='TIMESTAMP', type=argparse.FileType('rb'),
                                help='Timestamp filename')
@@ -253,9 +331,15 @@ def parse_ots_args(raw_args):
 
     parser_headers_fetch = headers_subparsers.add_parser('fetch',
                                                          help='Fetch headers from public sources into a local archive')
+    # The default is network-suffixed so that mainnet and testnet archives
+    # live at distinct paths and don't trigger a network-mismatch error
+    # when a user runs `ots headers fetch --btc-testnet` after building a
+    # mainnet archive (or vice versa). Resolved at parse time against the
+    # current --btc-* flag via set_defaults below.
     parser_headers_fetch.add_argument('--output', metavar='PATH', dest='headers_path', type=str,
-                                      default=os.path.join(APPDIRS.user_cache_dir, 'headers.bin'),
-                                      help='Path to the header archive file. Default: %(default)s')
+                                      default=None,
+                                      help='Path to the header archive file. '
+                                           'Default: <cache_dir>/headers-<network>.bin')
     parser_headers_fetch.add_argument('--since-height', dest='since_height', type=int,
                                       default=None,
                                       help='Lowest block height to fetch. Default: continue from end of '

--- a/otsclient/args.py
+++ b/otsclient/args.py
@@ -196,21 +196,51 @@ def handle_common_options(args, parser):
         """
         headers_path = getattr(args, 'headers_path', None)
         if headers_path is not None:
-            archive = otsclient.headers.HeaderArchive(headers_path)
-            if not archive.exists():
+            if not os.path.isfile(headers_path):
                 logging.error("Header archive not found: %s" % headers_path)
                 sys.exit(1)
+            # Dispatch on the file magic so --headers PATH accepts either
+            # the dense HeaderArchive (OTSH, built by bulk `ots headers fetch`)
+            # or the sparse VerifyCache (OTSV, built by sidecar
+            # `ots headers fetch <file>.ots`).
             try:
-                archive_network, _start, _count = archive.read_file_header()
-            except otsclient.headers.HeaderArchiveError as exp:
-                logging.error("Header archive is invalid: %s" % exp)
+                magic = otsclient.headers.detect_archive_format(headers_path)
+            except OSError as exp:
+                logging.error("Could not read header file %s: %s" % (
+                    headers_path, exp))
                 sys.exit(1)
-            if archive_network != args.btc_net:
+            if magic == otsclient.headers.ARCHIVE_MAGIC:
+                archive = otsclient.headers.HeaderArchive(headers_path)
+                try:
+                    archive_network, _start, _count = archive.read_file_header()
+                except otsclient.headers.HeaderArchiveError as exp:
+                    logging.error("Header archive is invalid: %s" % exp)
+                    sys.exit(1)
+                if archive_network != args.btc_net:
+                    logging.error(
+                        "Header archive network %r does not match selected network %r" % (
+                            archive_network, args.btc_net))
+                    sys.exit(1)
+                return otsclient.headers.LocalArchiveHeaderSource(archive)
+            elif magic == otsclient.headers.VERIFY_CACHE_MAGIC:
+                cache = otsclient.headers.VerifyCache(headers_path)
+                try:
+                    cache_network, _count = cache.read_file_header()
+                except otsclient.headers.HeaderArchiveError as exp:
+                    logging.error("Header sidecar is invalid: %s" % exp)
+                    sys.exit(1)
+                if cache_network != args.btc_net:
+                    logging.error(
+                        "Header sidecar network %r does not match selected network %r" % (
+                            cache_network, args.btc_net))
+                    sys.exit(1)
+                return otsclient.headers.LocalVerifyCacheHeaderSource(cache)
+            else:
                 logging.error(
-                    "Header archive network %r does not match selected network %r" % (
-                        archive_network, args.btc_net))
+                    "Header file %s has unrecognized magic %r; expected "
+                    "OTSH (dense archive) or OTSV (sparse sidecar)" % (
+                        headers_path, magic))
                 sys.exit(1)
-            return otsclient.headers.LocalArchiveHeaderSource(archive)
 
         if args.bitcoin_node is not None:
             proxy = setup_bitcoin()
@@ -331,15 +361,34 @@ def parse_ots_args(raw_args):
 
     parser_headers_fetch = headers_subparsers.add_parser('fetch',
                                                          help='Fetch headers from public sources into a local archive')
-    # The default is network-suffixed so that mainnet and testnet archives
-    # live at distinct paths and don't trigger a network-mismatch error
-    # when a user runs `ots headers fetch --btc-testnet` after building a
-    # mainnet archive (or vice versa). Resolved at parse time against the
-    # current --btc-* flag via set_defaults below.
+    # Two modes share this subcommand:
+    #   1. Bulk fetch (no positional OTS files): contiguous OTSH archive
+    #      built from --since-height/--until-height (or chain tip). Default
+    #      output is network-suffixed in the OS cache dir.
+    #   2. Sidecar fetch (positional OTS files present): sparse OTSV
+    #      archive covering only the heights attested by the given .ots
+    #      files. Default output is derived from the .ots filename so the
+    #      sidecar sits next to its proof.
+    parser_headers_fetch.add_argument('ots_files', metavar='OTS-FILE',
+                                      type=str, nargs='*', default=[],
+                                      help='If provided, build a sparse sidecar archive '
+                                           'covering only the Bitcoin block heights these '
+                                           '.ots files attest to. Pass the .ots files as '
+                                           'positional arguments. Otherwise, do a contiguous '
+                                           'bulk fetch (see --since/--until).')
     parser_headers_fetch.add_argument('--output', metavar='PATH', dest='headers_path', type=str,
                                       default=None,
                                       help='Path to the header archive file. '
-                                           'Default: <cache_dir>/headers-<network>.bin')
+                                           'Default in bulk mode: <cache_dir>/headers-<network>.bin. '
+                                           'Default in sidecar mode (single .ots): '
+                                           '<file>.ots-btc-headers.bin (sibling of the .ots). '
+                                           'Default in sidecar mode (multiple .ots): '
+                                           './ots-btc-headers.bin.')
+    parser_headers_fetch.add_argument('--force', dest='force_overwrite',
+                                      action='store_true', default=False,
+                                      help='In sidecar mode, overwrite an existing output file. '
+                                           'Bulk mode appends to an existing archive and ignores '
+                                           'this flag.')
     parser_headers_fetch.add_argument('--since-height', dest='since_height', type=int,
                                       default=None,
                                       help='Lowest block height to fetch. Default: continue from end of '

--- a/otsclient/args.py
+++ b/otsclient/args.py
@@ -373,6 +373,26 @@ def parse_ots_args(raw_args):
                                      help='Path to the header archive file')
     parser_headers_info.set_defaults(cmd_func=otsclient.cmds.headers_info_command)
 
+    parser_headers_bootstrap = headers_subparsers.add_parser(
+        'bootstrap',
+        help='Download a prebuilt header archive from a URL and install it locally')
+    parser_headers_bootstrap.add_argument('url', metavar='URL', type=str,
+        help='URL to download the archive from. Supports http(s)://, file://, '
+             'and any other scheme urllib.request handles.')
+    parser_headers_bootstrap.add_argument('--output', metavar='PATH',
+        dest='headers_path', type=str, default=None,
+        help='Where to install the validated archive. '
+             'Default: <cache_dir>/headers-<network>.bin')
+    parser_headers_bootstrap.add_argument('--sha256', metavar='HEX',
+        dest='expected_sha256', type=str, default=None,
+        help='Expected SHA-256 of the downloaded file (hex-encoded). '
+             'Optional but recommended when the URL points at a third-party host.')
+    parser_headers_bootstrap.add_argument('--force', dest='force_overwrite',
+        action='store_true', default=False,
+        help='Overwrite an existing archive at the output path. Without this, '
+             'bootstrap refuses to clobber an existing file.')
+    parser_headers_bootstrap.set_defaults(cmd_func=otsclient.cmds.headers_bootstrap_command)
+
     # ----- info -----
     parser_info = subparsers.add_parser('info', aliases=['i'],
                                         help='Show information on a timestamp')

--- a/otsclient/args.py
+++ b/otsclient/args.py
@@ -22,6 +22,7 @@ import opentimestamps.calendar
 import otsclient
 import otsclient.cache
 import otsclient.cmds
+import otsclient.headers
 
 APPDIRS = appdirs.AppDirs('ots','opentimestamps')
 
@@ -150,6 +151,35 @@ def handle_common_options(args, parser):
 
     args.setup_bitcoin = setup_bitcoin
 
+    def get_header_source():
+        """Return a BlockHeaderSource appropriate for the current args.
+
+        If --headers was given to the verify subcommand, use a local
+        archive. Otherwise fall back to the existing Bitcoin RPC proxy.
+        """
+        headers_path = getattr(args, 'headers_path', None)
+        if headers_path is not None:
+            archive = otsclient.headers.HeaderArchive(headers_path)
+            if not archive.exists():
+                logging.error("Header archive not found: %s" % headers_path)
+                sys.exit(1)
+            try:
+                archive_network, _start, _count = archive.read_file_header()
+            except otsclient.headers.HeaderArchiveError as exp:
+                logging.error("Header archive is invalid: %s" % exp)
+                sys.exit(1)
+            if archive_network != args.btc_net:
+                logging.error(
+                    "Header archive network %r does not match selected network %r" % (
+                        archive_network, args.btc_net))
+                sys.exit(1)
+            return otsclient.headers.LocalArchiveHeaderSource(archive)
+
+        proxy = setup_bitcoin()
+        return otsclient.headers.BitcoinNodeHeaderSource(proxy)
+
+    args.get_header_source = get_header_source
+
     return args
 
 def parse_ots_args(raw_args):
@@ -205,8 +235,50 @@ def parse_ots_args(raw_args):
                                      default=None,
                                      help='Verify a (hex-encoded) digest rather than a file')
 
+    parser_verify.add_argument('--headers', metavar='PATH', dest='headers_path', type=str,
+                               default=None,
+                               help='Verify using a local Bitcoin header archive (produced by '
+                                    '`ots headers fetch`) instead of a local Bitcoin node. '
+                                    'Enables fully offline verification.')
+
     parser_verify.add_argument('timestamp_fd', metavar='TIMESTAMP', type=argparse.FileType('rb'),
                                help='Timestamp filename')
+
+    # ----- headers -----
+    parser_headers = subparsers.add_parser('headers',
+                                           help='Manage local Bitcoin block header archive')
+    headers_subparsers = parser_headers.add_subparsers(
+        title='Subcommands',
+        description='Header archive operations:')
+
+    parser_headers_fetch = headers_subparsers.add_parser('fetch',
+                                                         help='Fetch headers from public sources into a local archive')
+    parser_headers_fetch.add_argument('--output', metavar='PATH', dest='headers_path', type=str,
+                                      default=os.path.join(APPDIRS.user_cache_dir, 'headers.bin'),
+                                      help='Path to the header archive file. Default: %(default)s')
+    parser_headers_fetch.add_argument('--since-height', dest='since_height', type=int,
+                                      default=None,
+                                      help='Lowest block height to fetch. Default: continue from end of '
+                                           'existing archive, or 0 if creating a new archive.')
+    parser_headers_fetch.add_argument('--until-height', dest='until_height', type=int,
+                                      default=None,
+                                      help='Highest block height to fetch (inclusive). '
+                                           'Default: current chain tip according to fetch sources.')
+    parser_headers_fetch.add_argument('--source', metavar='URL', dest='source_urls', action='append',
+                                      type=str, default=[],
+                                      help='Esplora-compatible base URL to fetch from. May be specified '
+                                           'multiple times. Defaults to a network-appropriate set of '
+                                           'public sources if not given.')
+    parser_headers_fetch.add_argument('--quorum', dest='quorum', type=int, default=None,
+                                      help='Minimum number of agreeing sources required per header. '
+                                           'Default: majority of provided sources (rounded up).')
+    parser_headers_fetch.set_defaults(cmd_func=otsclient.cmds.headers_fetch_command)
+
+    parser_headers_info = headers_subparsers.add_parser('info',
+                                                        help='Show information about a local header archive')
+    parser_headers_info.add_argument('archive_path', metavar='PATH', type=str,
+                                     help='Path to the header archive file')
+    parser_headers_info.set_defaults(cmd_func=otsclient.cmds.headers_info_command)
 
     # ----- info -----
     parser_info = subparsers.add_parser('info', aliases=['i'],

--- a/otsclient/cmds.py
+++ b/otsclient/cmds.py
@@ -38,6 +38,7 @@ from opentimestamps.bitcoin import *
 import opentimestamps.calendar
 
 import otsclient
+import otsclient.headers
 
 def remote_calendar(calendar_uri):
     """Create a remote calendar with User-Agent set appropriately"""
@@ -406,21 +407,18 @@ def verify_timestamp(timestamp, args):
                                 (attestation.height, b2lx(msg)))
                 continue
 
-            proxy = args.setup_bitcoin()
+            header_source = args.get_header_source()
 
             try:
-                block_count = proxy.getblockcount()
-                blockhash = proxy.getblockhash(attestation.height)
-            except IndexError:
-                logging.error("Bitcoin block height %d not found; %d is highest known block" % (attestation.height, block_count))
+                block_header = header_source.get_header_at_height(attestation.height)
+            except IndexError as exp:
+                logging.error("%s" % exp)
                 continue
             except ConnectionError as exp:
-                logging.error("Could not connect to local Bitcoin node: %s" % exp)
+                logging.error("Could not connect to header source: %s" % exp)
                 continue
 
-            block_header = proxy.getblockheader(blockhash)
-
-            logging.debug("Attestation block hash: %s" % b2lx(blockhash))
+            logging.debug("Attestation block hash: %s" % b2lx(block_header.GetHash()))
 
             try:
                 attested_time = attestation.verify_against_blockheader(msg, block_header)
@@ -517,19 +515,16 @@ def verify_all_attestations(timestamp, attestations_to_verify, args):
                     logging.error("Bitcoin disabled, could not check attestations")
                     sys.exit(1)
 
-                proxy = args.setup_bitcoin()
+                header_source = args.get_header_source()
 
                 try:
-                    block_count = proxy.getblockcount()
-                    blockhash = proxy.getblockhash(attestation.height)
-                    block_header = proxy.getblockheader(blockhash)
+                    block_header = header_source.get_header_at_height(attestation.height)
                     attested_time = attestation.verify_against_blockheader(msg, block_header)
-                except IndexError:
-                    logging.error("Bitcoin block height %d not found; %d is highest known block" % (
-                        attestation.height, block_count))
+                except IndexError as exp:
+                    logging.error("%s" % exp)
                     sys.exit(1)
                 except ConnectionError as exp:
-                    logging.error("Could not connect to local Bitcoin node: %s" % exp)
+                    logging.error("Could not connect to header source: %s" % exp)
                     sys.exit(1)
                 except VerificationError as err:
                     logging.error("Bitcoin verification failed: %s" % str(err))
@@ -827,3 +822,122 @@ def git_extract_command(args):
     except IOError as exp:
         logging.error("Failed to create timestamp %r: %s" % (timestamp_file_path, exp))
         sys.exit(1)
+
+
+def headers_fetch_command(args):
+    """Fetch Bitcoin block headers into a local archive."""
+    archive = otsclient.headers.HeaderArchive(args.headers_path)
+
+    # If the archive does not exist yet, create it. If it does exist,
+    # the network and start_height are already fixed and we just append.
+    if not archive.exists():
+        start_height = args.since_height if args.since_height is not None else 0
+        try:
+            archive.create(args.btc_net, start_height)
+            logging.info("Created header archive %s (network=%s, start_height=%d)" % (
+                args.headers_path, args.btc_net, start_height))
+        except otsclient.headers.HeaderArchiveError as exp:
+            logging.error("Could not create archive: %s" % exp)
+            sys.exit(1)
+
+    try:
+        archive_network, start_height, header_count = archive.read_file_header()
+    except otsclient.headers.HeaderArchiveError as exp:
+        logging.error("Invalid archive: %s" % exp)
+        sys.exit(1)
+
+    if archive_network != args.btc_net:
+        logging.error("Archive network %r does not match selected network %r" % (
+            archive_network, args.btc_net))
+        sys.exit(1)
+
+    # Resolve fetch sources
+    if args.source_urls:
+        sources = [otsclient.headers.EsploraHeaderFetcher(url) for url in args.source_urls]
+    else:
+        sources = otsclient.headers.make_default_esplora_sources(args.btc_net)
+        if not sources:
+            logging.error("No default fetch sources for network %r; provide --source URL(s)" %
+                          args.btc_net)
+            sys.exit(1)
+
+    fetcher = otsclient.headers.HeaderFetcher(sources, quorum=args.quorum)
+
+    # Resolve since_height: the next height to fetch.
+    next_height = start_height + header_count
+    if args.since_height is not None and args.since_height != next_height:
+        if args.since_height < next_height:
+            logging.info("Skipping --since-height %d; archive already has up to height %d" % (
+                args.since_height, next_height - 1))
+        else:
+            logging.error(
+                "Cannot fetch from height %d: archive ends at %d and headers must be appended in order" % (
+                    args.since_height, next_height - 1))
+            sys.exit(1)
+
+    # Resolve until_height. If not given, query sources for current chain tip
+    # and pick the median (resilient to a single source reporting a stale
+    # or future tip).
+    if args.until_height is None:
+        tip_heights = []
+        for source in sources:
+            try:
+                tip_heights.append(source.get_tip_height())
+            except Exception as exp:
+                logging.debug("Source %r failed tip lookup: %s" % (source.base_url, exp))
+        if not tip_heights:
+            logging.error("Could not determine chain tip from any source; "
+                          "use --until-height to specify explicitly")
+            sys.exit(1)
+        tip_heights.sort()
+        until_height = tip_heights[len(tip_heights) // 2]
+        logging.info("Auto-detected chain tip height %d (from %d source(s))" % (
+            until_height, len(tip_heights)))
+    else:
+        until_height = args.until_height
+
+    if until_height < next_height:
+        logging.info("Nothing to do: archive already covers up to height %d" % (next_height - 1))
+        return
+
+    logging.info("Fetching headers %d..%d from %d source(s), quorum=%d" % (
+        next_height, until_height, len(sources), fetcher.quorum))
+
+    fetched = 0
+    log_every = 100
+    for height in range(next_height, until_height + 1):
+        try:
+            header = fetcher.fetch_header(height)
+            archive.append_header(header)
+            fetched += 1
+        except (otsclient.headers.HeaderArchiveError, ConnectionError) as exp:
+            logging.error("Stopping at height %d: %s" % (height, exp))
+            sys.exit(1)
+
+        if fetched % log_every == 0:
+            logging.info("... fetched %d headers (at height %d)" % (fetched, height))
+
+    logging.info("Done. Fetched %d header(s); archive now covers %d..%d" % (
+        fetched, start_height, until_height))
+
+
+def headers_info_command(args):
+    """Print information about a local header archive."""
+    archive = otsclient.headers.HeaderArchive(args.archive_path)
+    if not archive.exists():
+        logging.error("Archive file not found: %s" % args.archive_path)
+        sys.exit(1)
+
+    try:
+        info = archive.info()
+    except otsclient.headers.HeaderArchiveError as exp:
+        logging.error("Invalid archive: %s" % exp)
+        sys.exit(1)
+
+    print("Path:         %s" % info['path'])
+    print("Network:      %s" % info['network'])
+    print("Header count: %d" % info['header_count'])
+    print("Height range: %d..%s" % (
+        info['start_height'],
+        info['end_height'] if info['end_height'] is not None else '(empty)'))
+    print("File size:    %d bytes" % info['file_size'])

--- a/otsclient/cmds.py
+++ b/otsclient/cmds.py
@@ -1018,3 +1018,43 @@ def headers_info_command(args):
         info['start_height'],
         info['end_height'] if info['end_height'] is not None else '(empty)'))
     print("File size:    %d bytes" % info['file_size'])
+
+
+def headers_bootstrap_command(args):
+    """Download a prebuilt header archive from a URL and install it locally.
+
+    The trust model is identical to an archive built via `ots headers fetch`:
+    PoW and prev-hash continuity are validated for every header before the
+    file is installed. The source URL doesn't need to be trusted -- the math
+    is the trust signal. Useful for grabbing a snapshot from GitHub Releases,
+    IPFS, a friend's mirror, etc., without spending the minutes a P2P fetch
+    or the hours an HTTP fetch would take.
+    """
+    if args.headers_path is None:
+        appdirs_default = appdirs.AppDirs('ots', 'opentimestamps')
+        args.headers_path = os.path.join(
+            appdirs_default.user_cache_dir,
+            'headers-%s.bin' % args.btc_net)
+
+    if os.path.exists(args.headers_path) and not args.force_overwrite:
+        logging.error(
+            "Output path already exists: %s\n"
+            "Pass --force to overwrite, or pick a different --output path." % (
+                args.headers_path))
+        sys.exit(1)
+
+    try:
+        info = otsclient.headers.bootstrap_archive_from_url(
+            url=args.url,
+            output_path=args.headers_path,
+            network=args.btc_net,
+            expected_sha256=args.expected_sha256)
+    except otsclient.headers.HeaderArchiveError as exp:
+        logging.error("%s" % exp)
+        sys.exit(1)
+
+    end_height = (info['start_height'] + info['header_count'] - 1
+                  if info['header_count'] > 0 else info['start_height'])
+    logging.info("Done. Installed %s (network=%s, headers=%d, heights %d..%d)" % (
+        info['path'], info['network'], info['header_count'],
+        info['start_height'], end_height))

--- a/otsclient/cmds.py
+++ b/otsclient/cmds.py
@@ -475,7 +475,7 @@ def verify_timestamp(timestamp, args):
 
             logging.info("Success! Bitcoin block %d attests existence as of %s" %
                             (attestation.height,
-                             time.strftime('%Y-%m-%d %Z',
+                             time.strftime('%Y-%m-%d %H:%M:%S %Z',
                                           time.localtime(attested_time))))
             good = True
 

--- a/otsclient/cmds.py
+++ b/otsclient/cmds.py
@@ -825,8 +825,21 @@ def git_extract_command(args):
 
 
 def headers_fetch_command(args):
-    """Fetch Bitcoin block headers into a local archive."""
+    """Fetch Bitcoin block headers into a local archive.
+
+    Two transports are supported. The HTTP fetcher (default) queries
+    Esplora-compatible block explorers; it's well-suited for small ranges
+    around a specific OTS attestation, with cross-source quorum agreement.
+    The P2P fetcher (--p2p, --p2p-peer) talks Bitcoin's native getheaders
+    protocol; it returns up to 2000 headers per round trip and is the
+    right choice for bulk fetches like populating from genesis.
+    """
     archive = otsclient.headers.HeaderArchive(args.headers_path)
+
+    use_p2p = args.use_p2p or bool(args.p2p_peers)
+    if use_p2p and args.source_urls:
+        logging.error("--p2p and --source are mutually exclusive")
+        sys.exit(1)
 
     # If the archive does not exist yet, create it. If it does exist,
     # the network and start_height are already fixed and we just append.
@@ -850,6 +863,10 @@ def headers_fetch_command(args):
         logging.error("Archive network %r does not match selected network %r" % (
             archive_network, args.btc_net))
         sys.exit(1)
+
+    if use_p2p:
+        _headers_fetch_p2p(args, archive)
+        return
 
     # Resolve fetch sources
     if args.source_urls:
@@ -919,6 +936,56 @@ def headers_fetch_command(args):
 
     logging.info("Done. Fetched %d header(s); archive now covers %d..%d" % (
         fetched, start_height, until_height))
+
+
+def _parse_p2p_peer_spec(spec):
+    """Parse a 'host' or 'host:port' string into a (host, port) tuple.
+
+    Defaults to the network's default port if no port is given.
+    """
+    if ':' in spec:
+        host, port_str = spec.rsplit(':', 1)
+        try:
+            port = int(port_str)
+        except ValueError:
+            raise ValueError("Invalid port in peer spec %r" % spec)
+    else:
+        host = spec
+        port = bitcoin.params.DEFAULT_PORT
+    return (host, port)
+
+
+def _headers_fetch_p2p(args, archive):
+    """Fetch headers via Bitcoin P2P getheaders."""
+    if args.p2p_peers:
+        try:
+            peers = [_parse_p2p_peer_spec(s) for s in args.p2p_peers]
+        except ValueError as exp:
+            logging.error("%s" % exp)
+            sys.exit(1)
+    else:
+        peers = None  # signals DNS-seed discovery
+
+    fetcher = otsclient.headers.BitcoinP2PHeaderFetcher(
+        network=args.btc_net,
+        peers=peers,
+    )
+
+    if args.until_height is not None:
+        logging.info("Fetching headers via Bitcoin P2P up to height %d" % args.until_height)
+    else:
+        logging.info("Fetching headers via Bitcoin P2P to the chain tip")
+
+    try:
+        appended = fetcher.fetch_into(archive, until_height=args.until_height)
+    except otsclient.headers.P2PFetcherError as exp:
+        logging.error("P2P fetch failed: %s" % exp)
+        sys.exit(1)
+
+    _network, start_height, header_count = archive.read_file_header()
+    end_height = start_height + header_count - 1
+    logging.info("Done. Appended %d header(s); archive now covers %d..%d" % (
+        appended, start_height, end_height))
 
 
 def headers_info_command(args):

--- a/otsclient/cmds.py
+++ b/otsclient/cmds.py
@@ -11,6 +11,7 @@
 
 import sys
 
+import appdirs
 import argparse
 import binascii
 import io
@@ -834,6 +835,15 @@ def headers_fetch_command(args):
     protocol; it returns up to 2000 headers per round trip and is the
     right choice for bulk fetches like populating from genesis.
     """
+    if args.headers_path is None:
+        # Default is network-suffixed so mainnet/testnet archives don't
+        # collide on the same default path. Lives in the OS cache dir
+        # regardless of --no-cache (which only disables the timestamp
+        # cache).
+        appdirs_default = appdirs.AppDirs('ots', 'opentimestamps')
+        args.headers_path = os.path.join(
+            appdirs_default.user_cache_dir, 'headers-%s.bin' % args.btc_net)
+
     archive = otsclient.headers.HeaderArchive(args.headers_path)
 
     use_p2p = args.use_p2p or bool(args.p2p_peers)

--- a/otsclient/cmds.py
+++ b/otsclient/cmds.py
@@ -41,6 +41,64 @@ import opentimestamps.calendar
 import otsclient
 import otsclient.headers
 
+def _deserialize_timestamp(fd, name):
+    """Deserialize a .ots from an already-open file handle.
+
+    Closes the handle and exits the process with a clear error if the
+    file is not a valid timestamp. Returns a DetachedTimestampFile.
+    Shared by verify, info, prune, upgrade, and sidecar-mode `headers
+    fetch`, all of which previously inlined the same try/except block.
+    """
+    try:
+        ctx = StreamDeserializationContext(fd)
+        try:
+            return DetachedTimestampFile.deserialize(ctx)
+        except BadMagicError:
+            logging.error("Error! %r is not a timestamp file." % name)
+            sys.exit(1)
+        except DeserializationError as exp:
+            logging.error("Invalid timestamp file %r: %s" % (name, exp))
+            sys.exit(1)
+    finally:
+        try:
+            fd.close()
+        except Exception:
+            pass
+
+
+def _load_timestamp_from_path(path):
+    """Open and deserialize a .ots file from a path.
+
+    Exits with a clear error on file-not-found or parse failure.
+    """
+    try:
+        fd = open(path, 'rb')
+    except FileNotFoundError:
+        logging.error("OTS file not found: %s" % path)
+        sys.exit(1)
+    except OSError as exp:
+        logging.error("Could not open %s: %s" % (path, exp))
+        sys.exit(1)
+    return _deserialize_timestamp(fd, path)
+
+
+def _extract_bitcoin_heights(timestamp):
+    """Walk a timestamp's attestations and report its Bitcoin heights.
+
+    Returns (sorted_heights_list, has_pending_bool). Callers can use the
+    pending flag to give clearer guidance when an .ots needs `ots upgrade`
+    before any concrete Bitcoin heights are available.
+    """
+    heights = set()
+    has_pending = False
+    for _msg, attestation in timestamp.all_attestations():
+        if attestation.__class__ == BitcoinBlockHeaderAttestation:
+            heights.add(attestation.height)
+        elif attestation.__class__ == PendingAttestation:
+            has_pending = True
+    return sorted(heights), has_pending
+
+
 def remote_calendar(calendar_uri):
     """Create a remote calendar with User-Agent set appropriately"""
     return opentimestamps.calendar.RemoteCalendar(calendar_uri,
@@ -338,19 +396,7 @@ def upgrade_timestamp(timestamp, args):
 def upgrade_command(args):
     for old_stamp_fd in args.files:
         logging.debug("Upgrading %s" % old_stamp_fd.name)
-
-        ctx = StreamDeserializationContext(old_stamp_fd)
-        try:
-            detached_timestamp = DetachedTimestampFile.deserialize(ctx)
-            old_stamp_fd.close()
-
-        # IOError's are already handled by argparse
-        except BadMagicError:
-            logging.error("Error! %r is not a timestamp file" % old_stamp_fd.name)
-            sys.exit(1)
-        except DeserializationError as exp:
-            logging.error("Invalid timestamp file %r: %s" % (old_stamp_fd.name, exp))
-            sys.exit(1)
+        detached_timestamp = _deserialize_timestamp(old_stamp_fd, old_stamp_fd.name)
 
         changed = upgrade_timestamp(detached_timestamp.timestamp, args)
 
@@ -440,15 +486,8 @@ def verify_timestamp(timestamp, args):
 
 
 def verify_command(args):
-    ctx = StreamDeserializationContext(args.timestamp_fd)
-    try:
-        detached_timestamp = DetachedTimestampFile.deserialize(ctx)
-    except BadMagicError:
-        logging.error("Error! %r is not a timestamp file." % args.timestamp_fd.name)
-        sys.exit(1)
-    except DeserializationError as exp:
-        logging.error("Invalid timestamp file %r: %s" % (args.timestamp_fd.name, exp))
-        sys.exit(1)
+    detached_timestamp = _deserialize_timestamp(
+        args.timestamp_fd, args.timestamp_fd.name)
 
     if args.hex_digest is not None:
         try:
@@ -491,15 +530,7 @@ def verify_command(args):
 
 
 def info_command(args):
-    ctx = StreamDeserializationContext(args.file)
-    try:
-        detached_timestamp = DetachedTimestampFile.deserialize(ctx)
-    except BadMagicError:
-        logging.error("Error! %r is not a timestamp file." % args.file.name)
-        sys.exit(1)
-    except DeserializationError as exp:
-        logging.error("Invalid timestamp file %r: %s" % (args.file.name, exp))
-        sys.exit(1)
+    detached_timestamp = _deserialize_timestamp(args.file, args.file.name)
 
     print("File %s hash: %s" % (detached_timestamp.file_hash_op.HASHLIB_NAME, hexlify(detached_timestamp.file_digest).decode('utf8')))
 
@@ -632,15 +663,8 @@ def prune_timestamp(timestamp, attestations_to_verify, attestations_to_discard, 
 
 
 def prune_command(args):
-    ctx = StreamDeserializationContext(args.timestamp_fd)
-    try:
-        detached_timestamp = DetachedTimestampFile.deserialize(ctx)
-    except BadMagicError:
-        logging.error("Error! %r is not a timestamp file." % args.timestamp_fd.name)
-        sys.exit(1)
-    except DeserializationError as exp:
-        logging.error("Invalid timestamp file %r: %s" % (args.timestamp_fd.name, exp))
-        sys.exit(1)
+    detached_timestamp = _deserialize_timestamp(
+        args.timestamp_fd, args.timestamp_fd.name)
 
     attestations_to_verify = []
     if args.attestations_to_verify:
@@ -828,16 +852,27 @@ def git_extract_command(args):
 def headers_fetch_command(args):
     """Fetch Bitcoin block headers into a local archive.
 
-    Two transports are supported. The HTTP fetcher (default) queries
-    Esplora-compatible block explorers; it's well-suited for small ranges
-    around a specific OTS attestation, with cross-source quorum agreement.
-    The P2P fetcher (--p2p, --p2p-peer) talks Bitcoin's native getheaders
-    protocol; it returns up to 2000 headers per round trip and is the
-    right choice for bulk fetches like populating from genesis.
+    Two modes share this entrypoint:
+
+    1. Bulk mode (no positional .ots files): contiguous OTSH archive
+       built from --since-height/--until-height (or chain tip). HTTP
+       fetcher (default) for small ranges with cross-source quorum;
+       P2P (--p2p, --p2p-peer) for fast bulk fetches via Bitcoin's
+       native getheaders protocol.
+
+    2. Sidecar mode (positional .ots files present): sparse OTSV archive
+       covering only the Bitcoin block heights those .ots files attest
+       to. Self-contained for offline verification of those proofs.
     """
+    sidecar_mode = bool(args.ots_files)
+
+    if sidecar_mode:
+        _headers_fetch_sidecar(args)
+        return
+
     if args.headers_path is None:
-        # Default is network-suffixed so mainnet/testnet archives don't
-        # collide on the same default path. Lives in the OS cache dir
+        # Bulk default: network-suffixed so mainnet/testnet archives
+        # don't collide on the same path. Lives in the OS cache dir
         # regardless of --no-cache (which only disables the timestamp
         # cache).
         appdirs_default = appdirs.AppDirs('ots', 'opentimestamps')
@@ -996,6 +1031,104 @@ def _headers_fetch_p2p(args, archive):
     end_height = start_height + header_count - 1
     logging.info("Done. Appended %d header(s); archive now covers %d..%d" % (
         appended, start_height, end_height))
+
+
+def _default_sidecar_path(ots_files):
+    """Derive the default sidecar output path from the input .ots files.
+
+    Single .ots input: sibling of the .ots, named <file>.ots-btc-headers.bin
+    (matches the existing .ots / .ots.bak naming family).
+    Multiple .ots inputs: generic ./ots-btc-headers.bin in CWD.
+    """
+    if len(ots_files) == 1:
+        path = ots_files[0]
+        if path.endswith('.ots'):
+            return path[:-4] + '.ots-btc-headers.bin'
+        return path + '-btc-headers.bin'
+    return 'ots-btc-headers.bin'
+
+
+def _headers_fetch_sidecar(args):
+    """Build a sparse sidecar covering only heights attested by args.ots_files."""
+    # Reject mode-incompatible flags up front.
+    incompatibilities = []
+    if args.use_p2p or args.p2p_peers:
+        incompatibilities.append(
+            "--p2p/--p2p-peer cannot be used in sidecar mode "
+            "(P2P fetches contiguous ranges; sidecars are sparse)")
+    if args.since_height is not None:
+        incompatibilities.append(
+            "--since-height cannot be used in sidecar mode "
+            "(heights are derived from the .ots files)")
+    if args.until_height is not None:
+        incompatibilities.append(
+            "--until-height cannot be used in sidecar mode "
+            "(heights are derived from the .ots files)")
+    if incompatibilities:
+        for msg in incompatibilities:
+            logging.error(msg)
+        sys.exit(1)
+
+    # Walk each .ots file to collect Bitcoin attestation heights.
+    all_heights = set()
+    for ots_path in args.ots_files:
+        detached = _load_timestamp_from_path(ots_path)
+        heights, has_pending = _extract_bitcoin_heights(detached.timestamp)
+        if not heights:
+            if has_pending:
+                logging.error(
+                    "%s has only PendingAttestations; upgrade it first "
+                    "(`ots upgrade %s`) so the sidecar can cover concrete "
+                    "Bitcoin heights." % (ots_path, ots_path))
+            else:
+                logging.error(
+                    "%s has no BitcoinBlockHeaderAttestation -- nothing "
+                    "to build a sidecar from." % ots_path)
+            sys.exit(1)
+        if has_pending:
+            logging.info(
+                "Note: %s has pending attestations alongside Bitcoin ones; "
+                "sidecar covers only the completed Bitcoin heights." % ots_path)
+        all_heights.update(heights)
+
+    if args.headers_path is None:
+        args.headers_path = _default_sidecar_path(args.ots_files)
+
+    if args.source_urls:
+        sources = [otsclient.headers.EsploraHeaderFetcher(url)
+                   for url in args.source_urls]
+    else:
+        sources = otsclient.headers.make_default_esplora_sources(args.btc_net)
+        if not sources:
+            logging.error(
+                "No public Esplora sources available for network %s. "
+                "Pass --source URL to specify one explicitly." % args.btc_net)
+            sys.exit(1)
+
+    quorum = args.quorum
+    if quorum is None:
+        quorum = (len(sources) + 1) // 2
+    try:
+        fetcher = otsclient.headers.HeaderFetcher(sources, quorum=quorum)
+    except ValueError as exp:
+        logging.error("%s" % exp)
+        sys.exit(1)
+
+    try:
+        info = otsclient.headers.build_sidecar_from_heights(
+            heights=sorted(all_heights),
+            output_path=args.headers_path,
+            network=args.btc_net,
+            fetcher=fetcher,
+            force=args.force_overwrite)
+    except otsclient.headers.HeaderArchiveError as exp:
+        logging.error("%s" % exp)
+        sys.exit(1)
+
+    logging.info(
+        "Done. Wrote sidecar %s (network=%s, %d header(s) for heights %s)" % (
+            info['path'], info['network'], info['header_count'],
+            ', '.join(str(h) for h in info['heights'])))
 
 
 def headers_info_command(args):

--- a/otsclient/headers.py
+++ b/otsclient/headers.py
@@ -430,6 +430,220 @@ def make_default_esplora_sources(network):
         raise ValueError("Unknown network: %s" % network)
 
 
+# Sparse on-disk cache of (height, header) pairs.
+#
+# Unlike HeaderArchive, which stores a contiguous range from start_height
+# onwards, VerifyCache stores arbitrary individual heights. It exists to
+# back the auto-fetch path used by `ots verify` when no Bitcoin node and
+# no explicit --headers archive are configured: each fetched header is
+# cached so subsequent verifications of the same proof are network-free.
+#
+# Format:
+#
+#   bytes  | field        | description
+#   -------+--------------+----------------------------------------------
+#   0..3   | magic        | 'OTSV' (4 ASCII bytes)
+#   4      | version_major| currently 1
+#   5      | version_minor| currently 0
+#   6      | network      | 0=mainnet, 1=testnet, 2=regtest
+#   7      | reserved     | 0x00
+#   8..15  | reserved     | 8 bytes, zero
+#
+# Followed by N records of 84 bytes each:
+#
+#   bytes  | field         | description
+#   -------+---------------+----------------------------------------------
+#   0..3   | height        | uint32 little-endian
+#   4..83  | header_bytes  | 80-byte serialized block header
+#
+# Records may appear in any order, and duplicates are tolerated (readers
+# return the first matching record). The file is append-only.
+
+VERIFY_CACHE_MAGIC = b'OTSV'
+VERIFY_CACHE_VERSION_MAJOR = 1
+VERIFY_CACHE_VERSION_MINOR = 0
+VERIFY_CACHE_FILE_HEADER_SIZE = 16
+VERIFY_CACHE_RECORD_SIZE = 4 + BLOCK_HEADER_SIZE
+
+
+class VerifyCache:
+    """Sparse on-disk cache of (height, CBlockHeader) pairs for auto-fetch.
+
+    Backs AutoFetchHeaderSource, which fills it lazily as `ots verify`
+    walks a timestamp proof. Each cached entry is PoW-validated at write
+    time, so a tampered cache file fails PoW on read.
+    """
+
+    def __init__(self, path):
+        self.path = path
+
+    def exists(self):
+        return os.path.isfile(self.path)
+
+    def create(self, network):
+        """Create a new empty verify cache for the given network.
+
+        Writes the 16-byte file header and nothing else. Raises
+        HeaderArchiveError if the file already exists.
+        """
+        if os.path.exists(self.path):
+            raise HeaderArchiveError("Verify cache file already exists: %s" % self.path)
+        if network not in NETWORK_NAME_TO_ID:
+            raise HeaderArchiveError("Unknown network: %s" % network)
+        os.makedirs(os.path.dirname(self.path) or '.', exist_ok=True)
+        with open(self.path, 'wb') as fd:
+            fd.write(struct.pack(
+                '<4sBBBB8s',
+                VERIFY_CACHE_MAGIC,
+                VERIFY_CACHE_VERSION_MAJOR,
+                VERIFY_CACHE_VERSION_MINOR,
+                NETWORK_NAME_TO_ID[network],
+                0,  # reserved byte
+                b'\x00' * 8,  # 8 reserved bytes
+            ))
+
+    def read_file_header(self):
+        """Return (network_name, record_count)."""
+        with open(self.path, 'rb') as fd:
+            buf = fd.read(VERIFY_CACHE_FILE_HEADER_SIZE)
+            if len(buf) < VERIFY_CACHE_FILE_HEADER_SIZE:
+                raise HeaderArchiveFormatError(
+                    "Verify cache too short to contain a file header: %s" % self.path)
+            magic, ver_maj, ver_min, network_id, _reserved1, _reserved2 = \
+                struct.unpack('<4sBBBB8s', buf)
+            if magic != VERIFY_CACHE_MAGIC:
+                raise HeaderArchiveFormatError(
+                    "Verify cache magic mismatch: got %r, expected %r" % (
+                        magic, VERIFY_CACHE_MAGIC))
+            if ver_maj != VERIFY_CACHE_VERSION_MAJOR:
+                raise HeaderArchiveFormatError(
+                    "Unsupported verify cache version: %d.%d (this client supports %d.x)" % (
+                        ver_maj, ver_min, VERIFY_CACHE_VERSION_MAJOR))
+            if network_id not in NETWORK_ID_TO_NAME:
+                raise HeaderArchiveFormatError(
+                    "Unknown network ID in verify cache: %d" % network_id)
+            file_size = os.path.getsize(self.path)
+            body_size = file_size - VERIFY_CACHE_FILE_HEADER_SIZE
+            if body_size % VERIFY_CACHE_RECORD_SIZE != 0:
+                raise HeaderArchiveFormatError(
+                    "Verify cache body size %d is not a multiple of %d" % (
+                        body_size, VERIFY_CACHE_RECORD_SIZE))
+            record_count = body_size // VERIFY_CACHE_RECORD_SIZE
+            return NETWORK_ID_TO_NAME[network_id], record_count
+
+    def iter_records(self):
+        """Yield (height, CBlockHeader) for each cached record, in file order."""
+        self.read_file_header()  # validate format before iterating
+        with open(self.path, 'rb') as fd:
+            fd.seek(VERIFY_CACHE_FILE_HEADER_SIZE)
+            while True:
+                buf = fd.read(VERIFY_CACHE_RECORD_SIZE)
+                if not buf:
+                    return
+                if len(buf) < VERIFY_CACHE_RECORD_SIZE:
+                    raise HeaderArchiveFormatError(
+                        "Truncated record in verify cache: %s" % self.path)
+                height = struct.unpack('<I', buf[:4])[0]
+                header = bitcoin.core.CBlockHeader.deserialize(buf[4:])
+                yield height, header
+
+    def get(self, height):
+        """Return the cached CBlockHeader at this height, or None if absent."""
+        for h, header in self.iter_records():
+            if h == height:
+                return header
+        return None
+
+    def add(self, height, header):
+        """Append a (height, header) record, validating proof-of-work.
+
+        Does not enforce chain-continuity, since cache entries are sparse.
+        The trust signal for AutoFetchHeaderSource is fetcher-level quorum
+        agreement plus this PoW check.
+
+        Raises HeaderArchiveChainError if PoW validation fails.
+        """
+        try:
+            bitcoin.core.CheckProofOfWork(header.GetHash(), header.nBits)
+        except bitcoin.core.CheckProofOfWorkError as exp:
+            raise HeaderArchiveChainError(
+                "Header at height %d fails proof-of-work check: %s" % (height, exp))
+        with open(self.path, 'ab') as fd:
+            fd.write(struct.pack('<I', height) + header.serialize())
+
+
+class AutoFetchHeaderSource(BlockHeaderSource):
+    """Block header source that fetches lazily from public HTTP sources.
+
+    The default for `ots verify` when no Bitcoin node and no explicit
+    --headers archive are configured. Each height looked up is fetched
+    once (with quorum agreement across multiple sources) and cached on
+    disk so subsequent verifications of the same proof are network-free.
+
+    Trust signal: quorum agreement across the fetcher's sources, plus
+    per-header proof-of-work validation. A tampered cache file would
+    simply fail PoW on read; a malicious source either fails quorum or
+    fails PoW.
+    """
+
+    def __init__(self, cache, fetcher, network, log=True):
+        self.cache = cache  # VerifyCache or None (caching disabled)
+        self.fetcher = fetcher
+        self.network = network
+        self.log = log
+
+    def _ensure_cache_for_network(self):
+        """Create the cache file if absent, or validate its network if present."""
+        if self.cache is None:
+            return
+        if self.cache.exists():
+            cache_network, _count = self.cache.read_file_header()
+            if cache_network != self.network:
+                raise HeaderArchiveNetworkMismatch(
+                    "Verify cache network %r does not match selected network %r" % (
+                        cache_network, self.network))
+        else:
+            self.cache.create(self.network)
+
+    def get_header_at_height(self, height):
+        if self.cache is not None and self.cache.exists():
+            cache_network, _count = self.cache.read_file_header()
+            if cache_network != self.network:
+                raise HeaderArchiveNetworkMismatch(
+                    "Verify cache network %r does not match selected network %r" % (
+                        cache_network, self.network))
+            cached = self.cache.get(height)
+            if cached is not None:
+                logging.debug("Verify cache hit for height %d" % height)
+                return cached
+
+        if self.log:
+            logging.info("Fetching block %d header from public sources..." % height)
+        header = self.fetcher.fetch_header(height)
+        # HeaderFetcher does quorum agreement but does not check PoW.
+        # We check it here so cached entries are always trustworthy.
+        try:
+            bitcoin.core.CheckProofOfWork(header.GetHash(), header.nBits)
+        except bitcoin.core.CheckProofOfWorkError as exp:
+            raise HeaderArchiveChainError(
+                "Fetched header at height %d fails proof-of-work check: %s" % (
+                    height, exp))
+
+        if self.cache is not None:
+            self._ensure_cache_for_network()
+            self.cache.add(height, header)
+        return header
+
+    def get_block_count(self):
+        """Query the underlying sources for the chain tip."""
+        for source in self.fetcher.sources:
+            try:
+                return source.get_tip_height()
+            except Exception as exp:
+                logging.debug("Source %r failed to return tip height: %s" % (source, exp))
+        raise HeaderArchiveError("No source returned a chain-tip height")
+
+
 # Bitcoin P2P getheaders SPV-style fetcher
 #
 # The HTTP-explorer fetcher above is fine for small ranges (one or a few

--- a/otsclient/headers.py
+++ b/otsclient/headers.py
@@ -22,13 +22,18 @@ bytes per block, the entire Bitcoin chain since 2009 fits in ~70 MB.
 This makes archival-quality, fully offline OTS verification practical.
 """
 
+import hashlib
+import io
 import logging
 import os
+import socket
 import struct
 import urllib.request
 
 import bitcoin
 import bitcoin.core
+import bitcoin.messages
+import bitcoin.net
 
 
 # On-disk archive format
@@ -423,6 +428,378 @@ def make_default_esplora_sources(network):
         return []
     else:
         raise ValueError("Unknown network: %s" % network)
+
+
+# Bitcoin P2P getheaders SPV-style fetcher
+#
+# The HTTP-explorer fetcher above is fine for small ranges (one or a few
+# headers around an OTS attestation). For bulk fetches -- the entire chain
+# or large ranges -- it's the wrong transport: per-block HTTP calls are
+# rate-limited and slow.
+#
+# Bitcoin's P2P `getheaders` message returns up to 2000 headers per round
+# trip. Full-chain fetch is ~475 round trips (a couple of minutes against a
+# typical peer) instead of millions of HTTP calls (days, plus rate limits).
+# This is the canonical SPV bulk-header path -- used by Electrum, BitcoinJ,
+# every wallet.
+#
+# python-bitcoinlib provides the message types (msg_version, msg_verack,
+# msg_getheaders, msg_headers); we add the connection loop and a small
+# workaround for one quirk: the headers wire format appends a 0x00 varint
+# after each 80-byte header (transaction count, always zero in this
+# context), and python-bitcoinlib's CBlockHeader.stream_deserialize doesn't
+# consume that trailing byte. We intercept the `headers` command at the
+# framing layer and parse the body ourselves so the trailing byte is
+# correctly skipped.
+
+P2P_DEFAULT_TIMEOUT = 30
+P2P_MESSAGE_HEADER_SIZE = 24  # magic(4) + command(12) + length(4) + checksum(4)
+
+
+class P2PFetcherError(HeaderArchiveError):
+    """Base class for Bitcoin P2P fetcher errors."""
+
+
+class P2PHandshakeError(P2PFetcherError):
+    """Failed to complete the version/verack handshake with a peer."""
+
+
+class P2PProtocolError(P2PFetcherError):
+    """Received an unexpected, malformed, or out-of-spec message from a peer."""
+
+
+def _read_exact(sock_file, n):
+    """Read exactly n bytes from a file-like, raising on short reads.
+
+    socket.makefile() with default buffering loops on read() until n bytes
+    are available, but the loop terminates early on EOF -- which is what we
+    want to detect explicitly here.
+    """
+    buf = sock_file.read(n)
+    if len(buf) < n:
+        raise EOFError("Expected %d bytes, got %d" % (n, len(buf)))
+    return buf
+
+
+def _read_p2p_message(sock_file):
+    """Read one P2P message from a socket-as-file, returning (command, body).
+
+    Generic message framing: magic + command + length + checksum + body.
+    Returns the command bytes (e.g. b'headers') and the body bytes;
+    callers are responsible for parsing the body according to command.
+
+    Raises P2PProtocolError on a bad magic or checksum.
+    """
+    header = _read_exact(sock_file, P2P_MESSAGE_HEADER_SIZE)
+    if header[:4] != bitcoin.params.MESSAGE_START:
+        raise P2PProtocolError("Bad message magic %s, expected %s" % (
+            header[:4].hex(), bitcoin.params.MESSAGE_START.hex()))
+    command = header[4:16].rstrip(b'\x00')
+    body_len = struct.unpack(b'<I', header[16:20])[0]
+    checksum = header[20:24]
+    body = _read_exact(sock_file, body_len)
+    expected_checksum = hashlib.sha256(hashlib.sha256(body).digest()).digest()[:4]
+    if checksum != expected_checksum:
+        raise P2PProtocolError("Bad checksum on '%s' message" % command.decode('ascii', 'replace'))
+    return command, body
+
+
+def _parse_headers_body(body):
+    """Parse the body of a P2P 'headers' message, returning a list of CBlockHeader.
+
+    Each entry in the wire format is 80 bytes of canonical block header
+    followed by a single 0x00 byte (the transaction-count varint, always
+    zero here since this is a header-only message).
+    """
+    f = io.BytesIO(body)
+    count = bitcoin.core.VarIntSerializer.stream_deserialize(f)
+    out = []
+    for _ in range(count):
+        header_bytes = f.read(80)
+        if len(header_bytes) < 80:
+            raise P2PProtocolError("Truncated header in headers message")
+        header = bitcoin.core.CBlockHeader.deserialize(header_bytes)
+        # Consume and discard the trailing transaction-count varint.
+        bitcoin.core.VarIntSerializer.stream_deserialize(f)
+        out.append(header)
+    return out
+
+
+def _send_p2p_message(sock, msg):
+    """Serialize a python-bitcoinlib MsgSerializable and send it to a socket.
+
+    `MsgSerializable.to_bytes()` already produces the fully-framed
+    message (magic + command + length + checksum + body).
+    """
+    sock.sendall(msg.to_bytes())
+
+
+def discover_p2p_peers_via_dns(network='mainnet', limit=20):
+    """Resolve the network's DNS seeds to a list of (host, port) tuples.
+
+    Returns at most `limit` peers, drawn round-robin across seeds so a
+    single seed's failure doesn't dominate. Failed seeds are silently
+    skipped; if all seeds fail, returns an empty list and the caller
+    should fall back to user-provided peers.
+    """
+    seeds = [hostname for (_label, hostname) in bitcoin.params.DNS_SEEDS]
+    port = bitcoin.params.DEFAULT_PORT
+    per_seed = []
+    for seed in seeds:
+        addrs = []
+        try:
+            for info in socket.getaddrinfo(seed, port, type=socket.SOCK_STREAM):
+                addrs.append((info[4][0], port))
+        except socket.gaierror as exp:
+            logging.debug("DNS seed %s failed: %s" % (seed, exp))
+        per_seed.append(addrs)
+
+    # Round-robin across seeds so we don't get stuck on a slow/bad one.
+    out = []
+    while len(out) < limit:
+        added = False
+        for addrs in per_seed:
+            if addrs:
+                out.append(addrs.pop(0))
+                added = True
+                if len(out) >= limit:
+                    break
+        if not added:
+            break
+    return out
+
+
+class _P2PPeerSession:
+    """A short-lived Bitcoin P2P session for fetching headers from one peer.
+
+    Use as a context manager:
+
+        with _P2PPeerSession(host, port) as session:
+            headers = session.request_headers(locator_hash)
+            ...
+
+    The session handles the version/verack handshake on entry and closes
+    the socket on exit. Slow/unresponsive peers are bounded by a per-call
+    socket timeout (default 30 seconds).
+    """
+
+    def __init__(self, host, port, timeout=P2P_DEFAULT_TIMEOUT):
+        self.host = host
+        self.port = port
+        self.timeout = timeout
+        self.sock = None
+        self.sock_file = None
+
+    def __enter__(self):
+        self.sock = socket.create_connection((self.host, self.port), timeout=self.timeout)
+        # Default buffering ensures read(n) loops until n bytes are available
+        # (or EOF). Headers messages can be ~162 KB and need that loop.
+        self.sock_file = self.sock.makefile('rb')
+        try:
+            self._handshake()
+        except Exception:
+            self._close()
+            raise
+        return self
+
+    def __exit__(self, *exc):
+        self._close()
+
+    def _close(self):
+        for resource in (self.sock_file, self.sock):
+            if resource is not None:
+                try:
+                    resource.close()
+                except Exception:
+                    pass
+        self.sock_file = None
+        self.sock = None
+
+    def _handshake(self):
+        """Perform the version/verack handshake. Both directions exchange both messages."""
+        _send_p2p_message(self.sock, bitcoin.messages.msg_version())
+        got_version = False
+        got_verack = False
+        # Bound the handshake so a misbehaving peer can't keep us looping.
+        for _ in range(20):
+            command, body = _read_p2p_message(self.sock_file)
+            if command == b'version':
+                got_version = True
+                _send_p2p_message(self.sock, bitcoin.messages.msg_verack())
+            elif command == b'verack':
+                got_verack = True
+            # Other messages (alert, sendheaders, sendcmpct, etc.) are ignored.
+            if got_version and got_verack:
+                return
+        raise P2PHandshakeError("Did not complete handshake with %s:%d" % (self.host, self.port))
+
+    def request_headers(self, locator_hash, hashstop=None):
+        """Send a getheaders request and return the resulting list of CBlockHeader.
+
+        `locator_hash` is the bytes of the most recent block we have (in
+        internal byte order, i.e. matching CBlockHeader.GetHash()). The
+        peer will respond with up to 2000 headers starting from the block
+        AFTER the one we name.
+
+        If `hashstop` is None, the peer sends as many headers as it
+        wishes (up to 2000); otherwise it stops at the named hash.
+
+        Returns an empty list if the peer thinks we're already at its tip.
+        Other unsolicited messages (ping, inv, addr) are handled or
+        ignored while waiting for the headers response.
+        """
+        gh = bitcoin.messages.msg_getheaders()
+        gh.locator.vHave = [locator_hash]
+        if hashstop is not None:
+            gh.hashstop = hashstop
+        _send_p2p_message(self.sock, gh)
+
+        # Bound the wait so a peer that just sends pings forever can't
+        # deadlock us.
+        for _ in range(50):
+            command, body = _read_p2p_message(self.sock_file)
+            if command == b'headers':
+                return _parse_headers_body(body)
+            elif command == b'ping':
+                # Respond to keep the connection alive while we wait.
+                pong = bitcoin.messages.msg_pong()
+                pong.nonce = struct.unpack(b'<Q', body[:8])[0]
+                _send_p2p_message(self.sock, pong)
+            # Everything else (inv, addr, alert, getheaders from the peer,
+            # etc.) is ignored -- we're only looking for our headers reply.
+        raise P2PProtocolError("Did not receive headers response from %s:%d" % (
+            self.host, self.port))
+
+
+class BitcoinP2PHeaderFetcher:
+    """Fetch Bitcoin block headers via the Bitcoin P2P protocol.
+
+    Significantly faster than HTTP-explorer fetching for bulk operations:
+    a single getheaders round trip returns up to 2000 headers, so the
+    full chain since 2009 fetches in a couple of minutes against a
+    responsive peer.
+
+    Uses one peer at a time; on peer failure (connection refused, slow
+    peer, malformed response, headers that fail PoW or chain-continuity
+    validation), falls through to the next peer. PoW + prev-hash
+    continuity is the trust anchor: a malicious peer can only feed us
+    chains that fail PoW, which we catch and treat as cause to drop the
+    peer.
+
+    This fetcher only supports archives that begin at the genesis block
+    (start_height == 0). Partial archives starting at a higher height
+    require knowing the exact previous-block hash to construct the
+    locator, which we don't have a portable source for; use the HTTP
+    fetcher (EsploraHeaderFetcher) for those cases.
+    """
+
+    def __init__(self, network='mainnet', peers=None, timeout=P2P_DEFAULT_TIMEOUT,
+                 dns_discovery_limit=20):
+        self.network = network
+        self._explicit_peers = list(peers) if peers else None
+        self.timeout = timeout
+        self.dns_discovery_limit = dns_discovery_limit
+
+    def get_peers(self):
+        """Return the list of (host, port) peers to try, in order."""
+        if self._explicit_peers is not None:
+            return list(self._explicit_peers)
+        return discover_p2p_peers_via_dns(self.network, limit=self.dns_discovery_limit)
+
+    def fetch_into(self, archive, until_height=None):
+        """Fetch headers into the given archive, starting from where it left off.
+
+        Connects to peers in turn; for each peer, requests batches of up
+        to 2000 headers in a loop, validating each header via
+        archive.append_header (which checks PoW and prev-hash continuity).
+
+        If until_height is given, stops appending once that height is
+        reached; otherwise continues until the peer reports we're at the
+        chain tip (empty headers response).
+
+        Returns the number of headers appended in this call.
+        """
+        _network, start_height, header_count = archive.read_file_header()
+        if start_height != 0:
+            raise P2PFetcherError(
+                "P2P fetcher only supports archives starting at genesis (height 0); "
+                "got start_height=%d. Use the HTTP fetcher for partial archives." % start_height)
+
+        # Seed an empty archive with genesis so subsequent locators have
+        # something to anchor to. Peers respond to a zero-hash locator by
+        # sending headers starting at height 1, not at genesis.
+        if header_count == 0:
+            genesis = bitcoin.params.GENESIS_BLOCK
+            if hasattr(genesis, 'get_header'):
+                genesis = genesis.get_header()
+            archive.append_header(genesis)
+            logging.debug("Seeded empty archive with genesis (network=%s)" % self.network)
+
+        peers = self.get_peers()
+        if not peers:
+            raise P2PFetcherError(
+                "No Bitcoin P2P peers available "
+                "(DNS seed discovery returned nothing; try --p2p-peer host[:port])")
+
+        appended_total = 0
+        for peer_host, peer_port in peers:
+            try:
+                with _P2PPeerSession(peer_host, peer_port, self.timeout) as session:
+                    appended_from_this_peer = self._drain_peer(
+                        session, archive, until_height)
+                    appended_total += appended_from_this_peer
+                    if appended_from_this_peer == 0:
+                        # Peer says we're done (returned an empty headers list).
+                        return appended_total
+            except (socket.error, EOFError, P2PFetcherError) as exp:
+                logging.debug("P2P peer %s:%d failed (appended=%d so far): %s" % (
+                    peer_host, peer_port, appended_total, exp))
+                continue
+
+        if appended_total == 0:
+            raise P2PFetcherError(
+                "All %d peer(s) failed without appending any headers" % len(peers))
+        return appended_total
+
+    def _drain_peer(self, session, archive, until_height, log_every=5000):
+        """Repeatedly request headers from one peer until done or it stops responding.
+
+        Returns the number of headers appended via this peer in this call.
+        Logs progress every `log_every` headers so a multi-minute bulk
+        fetch isn't silent.
+        """
+        appended = 0
+        next_log_at = log_every
+        while True:
+            _network, start_height, header_count = archive.read_file_header()
+            tip_header = archive.get_header_at_height(start_height + header_count - 1)
+            locator_hash = tip_header.GetHash()
+
+            batch = session.request_headers(locator_hash)
+            if not batch:
+                # Peer believes we're at the chain tip.
+                return appended
+
+            for header in batch:
+                if until_height is not None:
+                    _net, sh, hc = archive.read_file_header()
+                    if sh + hc - 1 >= until_height:
+                        return appended
+                try:
+                    archive.append_header(header)
+                    appended += 1
+                except HeaderArchiveChainError as exp:
+                    # A header that fails PoW or chain continuity means
+                    # this peer is feeding us bad data. Stop with this peer;
+                    # the outer loop will try the next one.
+                    raise P2PProtocolError(
+                        "Peer returned invalid header: %s" % exp)
+
+                if appended >= next_log_at:
+                    _net, sh, hc = archive.read_file_header()
+                    logging.info("... fetched %d headers (at height %d)" % (
+                        appended, sh + hc - 1))
+                    next_log_at += log_every
 
 
 # vim:syntax=python filetype=python

--- a/otsclient/headers.py
+++ b/otsclient/headers.py
@@ -1,0 +1,428 @@
+# Copyright (C) 2026 The OpenTimestamps developers
+#
+# This file is part of the OpenTimestamps Client.
+#
+# It is subject to the license terms in the LICENSE file found in the top-level
+# directory of this distribution.
+#
+# No part of the OpenTimestamps Client, including this file, may be copied,
+# modified, propagated, or distributed except according to the terms contained
+# in the LICENSE file.
+
+"""Bitcoin block header sources for OpenTimestamps verification.
+
+Provides a small abstraction over "where do we get a block header from" so
+that verification can use either a local Bitcoin node (existing behavior),
+a local on-disk archive of block headers (this module's main feature), or
+any future source via the BlockHeaderSource interface.
+
+The on-disk archive is an append-only file of canonically-serialized
+80-byte Bitcoin block headers with a 16-byte file-level header. At 80
+bytes per block, the entire Bitcoin chain since 2009 fits in ~70 MB.
+This makes archival-quality, fully offline OTS verification practical.
+"""
+
+import logging
+import os
+import struct
+import urllib.request
+
+import bitcoin
+import bitcoin.core
+
+
+# On-disk archive format
+#
+# A header archive starts with a 16-byte file-level header:
+#
+#   bytes  | field        | description
+#   -------+--------------+----------------------------------------------
+#   0..3   | magic        | 'OTSH' (4 ASCII bytes)
+#   4      | version_major| currently 1
+#   5      | version_minor| currently 0
+#   6      | network      | 0=mainnet, 1=testnet, 2=regtest
+#   7      | reserved     | 0x00
+#   8..11  | start_height | uint32 little-endian; height of the first
+#                        |   block header stored in this archive
+#   12..15 | reserved     | 4 bytes, zero
+#
+# Followed by N consecutive 80-byte block headers. Block N (for the lowest
+# N stored) is at offset 16; block N+1 at offset 16+80; etc.
+
+ARCHIVE_MAGIC = b'OTSH'
+ARCHIVE_VERSION_MAJOR = 1
+ARCHIVE_VERSION_MINOR = 0
+ARCHIVE_FILE_HEADER_SIZE = 16
+BLOCK_HEADER_SIZE = 80
+
+NETWORK_ID_MAINNET = 0
+NETWORK_ID_TESTNET = 1
+NETWORK_ID_REGTEST = 2
+
+NETWORK_NAME_TO_ID = {
+    'mainnet': NETWORK_ID_MAINNET,
+    'testnet': NETWORK_ID_TESTNET,
+    'regtest': NETWORK_ID_REGTEST,
+}
+
+NETWORK_ID_TO_NAME = {v: k for k, v in NETWORK_NAME_TO_ID.items()}
+
+
+class HeaderArchiveError(Exception):
+    """Base class for header archive errors."""
+
+
+class HeaderArchiveFormatError(HeaderArchiveError):
+    """Raised when an archive file is malformed or has the wrong magic."""
+
+
+class HeaderArchiveNetworkMismatch(HeaderArchiveError):
+    """Raised when an archive was built for a different network than requested."""
+
+
+class HeaderArchiveChainError(HeaderArchiveError):
+    """Raised when an archive fails prev-hash continuity or PoW validation."""
+
+
+class HeaderArchive:
+    """Read-write append-only archive of Bitcoin block headers.
+
+    Headers are stored sequentially starting at `start_height`. The archive
+    file may be opened in read mode (default) or read-write mode for
+    appending new headers.
+    """
+
+    def __init__(self, path):
+        self.path = path
+
+    def exists(self):
+        return os.path.isfile(self.path)
+
+    def create(self, network, start_height):
+        """Create a new empty archive for the given network and start height.
+
+        Writes the 16-byte file header and nothing else.
+        Raises HeaderArchiveError if the file already exists.
+        """
+        if os.path.exists(self.path):
+            raise HeaderArchiveError("Archive file already exists: %s" % self.path)
+
+        if network not in NETWORK_NAME_TO_ID:
+            raise HeaderArchiveError("Unknown network: %s" % network)
+
+        os.makedirs(os.path.dirname(self.path) or '.', exist_ok=True)
+        with open(self.path, 'wb') as fd:
+            fd.write(self._pack_file_header(network, start_height))
+
+    def _pack_file_header(self, network, start_height):
+        return struct.pack(
+            '<4sBBBBI4s',
+            ARCHIVE_MAGIC,
+            ARCHIVE_VERSION_MAJOR,
+            ARCHIVE_VERSION_MINOR,
+            NETWORK_NAME_TO_ID[network],
+            0,  # reserved byte
+            start_height,
+            b'\x00\x00\x00\x00',  # 4 reserved bytes
+        )
+
+    def read_file_header(self):
+        """Read and return (network, start_height, header_count)."""
+        with open(self.path, 'rb') as fd:
+            buf = fd.read(ARCHIVE_FILE_HEADER_SIZE)
+            if len(buf) < ARCHIVE_FILE_HEADER_SIZE:
+                raise HeaderArchiveFormatError(
+                    "Archive file too short to contain a file header: %s" % self.path)
+
+            magic, ver_maj, ver_min, network_id, _reserved1, start_height, _reserved2 = \
+                struct.unpack('<4sBBBBI4s', buf)
+
+            if magic != ARCHIVE_MAGIC:
+                raise HeaderArchiveFormatError(
+                    "Archive magic mismatch: got %r, expected %r" % (magic, ARCHIVE_MAGIC))
+
+            if ver_maj != ARCHIVE_VERSION_MAJOR:
+                raise HeaderArchiveFormatError(
+                    "Unsupported archive version: %d.%d (this client supports %d.x)" % (
+                        ver_maj, ver_min, ARCHIVE_VERSION_MAJOR))
+
+            if network_id not in NETWORK_ID_TO_NAME:
+                raise HeaderArchiveFormatError(
+                    "Unknown network ID in archive: %d" % network_id)
+
+            file_size = os.path.getsize(self.path)
+            body_size = file_size - ARCHIVE_FILE_HEADER_SIZE
+            if body_size % BLOCK_HEADER_SIZE != 0:
+                raise HeaderArchiveFormatError(
+                    "Archive body size %d is not a multiple of %d" % (
+                        body_size, BLOCK_HEADER_SIZE))
+
+            header_count = body_size // BLOCK_HEADER_SIZE
+            return NETWORK_ID_TO_NAME[network_id], start_height, header_count
+
+    def get_header_at_height(self, height):
+        """Return the bitcoin.core.CBlockHeader at this height.
+
+        Raises IndexError if the height is outside the archive's range.
+        """
+        _network, start_height, header_count = self.read_file_header()
+        end_height = start_height + header_count - 1
+
+        if height < start_height or height > end_height:
+            raise IndexError(
+                "Height %d outside archive range %d-%d" % (height, start_height, end_height))
+
+        offset = ARCHIVE_FILE_HEADER_SIZE + (height - start_height) * BLOCK_HEADER_SIZE
+        with open(self.path, 'rb') as fd:
+            fd.seek(offset)
+            raw = fd.read(BLOCK_HEADER_SIZE)
+            if len(raw) != BLOCK_HEADER_SIZE:
+                raise HeaderArchiveFormatError(
+                    "Short read at offset %d: got %d bytes, expected %d" % (
+                        offset, len(raw), BLOCK_HEADER_SIZE))
+            return bitcoin.core.CBlockHeader.deserialize(raw)
+
+    def append_header(self, header):
+        """Append a single header, validating prev-hash continuity and PoW.
+
+        Raises HeaderArchiveChainError on validation failure.
+        """
+        network, start_height, header_count = self.read_file_header()
+        next_height = start_height + header_count
+
+        # Chain continuity: header's prev_block_hash must match the previously-
+        # stored header's hash. Skip the check if this is the first header.
+        if header_count > 0:
+            prev_header = self.get_header_at_height(next_height - 1)
+            if header.hashPrevBlock != prev_header.GetHash():
+                raise HeaderArchiveChainError(
+                    "Header at height %d does not chain to height %d: "
+                    "prev_block_hash=%s, expected=%s" % (
+                        next_height, next_height - 1,
+                        header.hashPrevBlock.hex(), prev_header.GetHash().hex()))
+
+        # Proof of work: hash(header) must satisfy the difficulty target
+        # claimed in the header itself. This does NOT validate that the
+        # nBits value is correct relative to the difficulty-adjustment
+        # algorithm (which would require knowledge of the previous 2016
+        # blocks); the fetcher's quorum logic provides that protection.
+        #
+        # CheckProofOfWork raises on failure and returns None on success.
+        try:
+            bitcoin.core.CheckProofOfWork(header.GetHash(), header.nBits)
+        except bitcoin.core.CheckProofOfWorkError as exp:
+            raise HeaderArchiveChainError(
+                "Header at height %d fails proof-of-work check: %s" % (next_height, exp))
+
+        with open(self.path, 'ab') as fd:
+            fd.write(header.serialize())
+
+    def append_headers(self, headers):
+        """Append multiple headers in order, validating each."""
+        for h in headers:
+            self.append_header(h)
+
+    def info(self):
+        """Return a dict summarizing the archive."""
+        network, start_height, header_count = self.read_file_header()
+        return {
+            'path': self.path,
+            'network': network,
+            'start_height': start_height,
+            'header_count': header_count,
+            'end_height': start_height + header_count - 1 if header_count > 0 else None,
+            'file_size': os.path.getsize(self.path),
+        }
+
+
+class BlockHeaderSource:
+    """Abstract source of Bitcoin block headers for OTS verification."""
+
+    def get_header_at_height(self, height):
+        """Return a bitcoin.core.CBlockHeader at this height.
+
+        Raises IndexError if the height is not available.
+        """
+        raise NotImplementedError
+
+    def get_block_count(self):
+        """Return the highest known block height, if knowable.
+
+        Some sources (e.g., a finite archive) may not have a well-defined
+        notion of "the chain tip"; those should return the highest height
+        they have available.
+        """
+        raise NotImplementedError
+
+
+class BitcoinNodeHeaderSource(BlockHeaderSource):
+    """Block header source backed by a python-bitcoinlib RPC proxy.
+
+    Preserves the existing pre-2026 verify behavior: connect to a local
+    Bitcoin Core node and fetch headers via JSON-RPC.
+    """
+
+    def __init__(self, proxy):
+        self.proxy = proxy
+
+    def get_header_at_height(self, height):
+        block_count = self.proxy.getblockcount()
+        if height > block_count:
+            raise IndexError(
+                "Bitcoin block height %d not found; %d is highest known block" % (
+                    height, block_count))
+        blockhash = self.proxy.getblockhash(height)
+        return self.proxy.getblockheader(blockhash)
+
+    def get_block_count(self):
+        return self.proxy.getblockcount()
+
+
+class LocalArchiveHeaderSource(BlockHeaderSource):
+    """Block header source backed by a local on-disk header archive."""
+
+    def __init__(self, archive):
+        self.archive = archive
+
+    def get_header_at_height(self, height):
+        return self.archive.get_header_at_height(height)
+
+    def get_block_count(self):
+        _network, start_height, header_count = self.archive.read_file_header()
+        if header_count == 0:
+            return 0
+        return start_height + header_count - 1
+
+
+class EsploraHeaderFetcher:
+    """Fetch Bitcoin block headers from an Esplora-compatible HTTP API.
+
+    Used as a source for HeaderFetcher. Speaks the de facto Esplora API
+    (blockstream.info, mempool.space, etc.):
+
+        GET /block-height/<N>   -> blockhash (hex, big-endian display order)
+        GET /block/<hash>/raw   -> first 80 bytes are the block header
+
+    Note: Esplora's /block/<hash>/header endpoint exists on some deployments
+    but not all; the /raw endpoint plus a 80-byte read is more portable.
+    """
+
+    USER_AGENT = "OpenTimestamps-Client headers-fetcher"
+
+    def __init__(self, base_url, timeout=10):
+        self.base_url = base_url.rstrip('/')
+        self.timeout = timeout
+
+    def _http_get(self, path):
+        req = urllib.request.Request(self.base_url + path,
+                                     headers={'User-Agent': self.USER_AGENT})
+        with urllib.request.urlopen(req, timeout=self.timeout) as resp:
+            return resp.read()
+
+    def get_blockhash_at_height(self, height):
+        """Return the block hash (bytes, internal byte order) at this height."""
+        raw = self._http_get('/block-height/%d' % height)
+        hex_display = raw.decode('ascii').strip()
+        # Esplora returns hashes in display (big-endian) order; convert to
+        # internal (little-endian) order to match python-bitcoinlib.
+        return bytes.fromhex(hex_display)[::-1]
+
+    def get_header_at_height(self, height):
+        """Return a CBlockHeader for the block at this height."""
+        block_hash = self.get_blockhash_at_height(height)
+        hex_display = block_hash[::-1].hex()
+        raw_block = self._http_get('/block/%s/raw' % hex_display)
+        if len(raw_block) < BLOCK_HEADER_SIZE:
+            raise HeaderArchiveError(
+                "Esplora returned %d bytes for /block/%s/raw, expected at least %d" % (
+                    len(raw_block), hex_display, BLOCK_HEADER_SIZE))
+        return bitcoin.core.CBlockHeader.deserialize(raw_block[:BLOCK_HEADER_SIZE])
+
+    def get_tip_height(self):
+        """Return the current chain tip height according to this source."""
+        raw = self._http_get('/blocks/tip/height')
+        return int(raw.decode('ascii').strip())
+
+
+class HeaderFetcher:
+    """Fetch block headers from one or more sources with optional quorum.
+
+    Given a list of source objects that each implement
+    `get_header_at_height(height) -> CBlockHeader`, query all sources
+    and require quorum agreement on the serialized header bytes before
+    returning. PoW and prev-hash continuity checks are the responsibility
+    of HeaderArchive.append_header.
+    """
+
+    def __init__(self, sources, quorum=None):
+        if not sources:
+            raise ValueError("HeaderFetcher requires at least one source")
+        self.sources = list(sources)
+        # Default quorum: majority of sources (rounded up).
+        if quorum is None:
+            quorum = (len(self.sources) + 1) // 2
+        if quorum < 1 or quorum > len(self.sources):
+            raise ValueError("Quorum %d outside valid range 1..%d" % (
+                quorum, len(self.sources)))
+        self.quorum = quorum
+
+    def fetch_header(self, height):
+        """Fetch a header at the given height, requiring quorum agreement.
+
+        Raises HeaderArchiveError if quorum cannot be reached.
+        """
+        results_by_serialized = {}
+        errors = []
+        for source in self.sources:
+            try:
+                header = source.get_header_at_height(height)
+                key = bytes(header.serialize())
+                results_by_serialized.setdefault(key, []).append(source)
+            except Exception as exp:
+                errors.append((source, exp))
+                logging.debug("Source %r failed for height %d: %s" % (source, height, exp))
+
+        if not results_by_serialized:
+            raise HeaderArchiveError(
+                "No source returned a header for height %d (errors: %s)" % (
+                    height, errors))
+
+        # Pick the serialized form with the most agreeing sources.
+        best_serialized, best_sources = max(
+            results_by_serialized.items(), key=lambda kv: len(kv[1]))
+
+        if len(best_sources) < self.quorum:
+            raise HeaderArchiveError(
+                "Quorum %d not reached for height %d: best agreement was %d source(s) "
+                "(total responses: %d; errors: %d)" % (
+                    self.quorum, height, len(best_sources),
+                    sum(len(v) for v in results_by_serialized.values()),
+                    len(errors)))
+
+        return bitcoin.core.CBlockHeader.deserialize(best_serialized)
+
+
+def make_default_esplora_sources(network):
+    """Return a list of default EsploraHeaderFetcher sources for a network.
+
+    Mainnet has multiple independent Esplora deployments; testnet and
+    regtest have fewer (regtest has none, by definition).
+    """
+    if network == 'mainnet':
+        return [
+            EsploraHeaderFetcher('https://blockstream.info/api'),
+            EsploraHeaderFetcher('https://mempool.space/api'),
+            EsploraHeaderFetcher('https://mempool.emzy.de/api'),
+        ]
+    elif network == 'testnet':
+        return [
+            EsploraHeaderFetcher('https://blockstream.info/testnet/api'),
+            EsploraHeaderFetcher('https://mempool.space/testnet/api'),
+        ]
+    elif network == 'regtest':
+        return []
+    else:
+        raise ValueError("Unknown network: %s" % network)
+
+
+# vim:syntax=python filetype=python

--- a/otsclient/headers.py
+++ b/otsclient/headers.py
@@ -155,7 +155,10 @@ class HeaderArchive:
                 raise HeaderArchiveFormatError(
                     "Unknown network ID in archive: %d" % network_id)
 
-            file_size = os.path.getsize(self.path)
+            # Stat the already-open descriptor rather than re-resolving the
+            # path, so the size describes the same inode we just read the
+            # header bytes from even if the path is concurrently replaced.
+            file_size = os.fstat(fd.fileno()).st_size
             body_size = file_size - ARCHIVE_FILE_HEADER_SIZE
             if body_size % BLOCK_HEADER_SIZE != 0:
                 raise HeaderArchiveFormatError(
@@ -522,7 +525,8 @@ class VerifyCache:
             if network_id not in NETWORK_ID_TO_NAME:
                 raise HeaderArchiveFormatError(
                     "Unknown network ID in verify cache: %d" % network_id)
-            file_size = os.path.getsize(self.path)
+            # Same inode-consistency reasoning as HeaderArchive.read_file_header.
+            file_size = os.fstat(fd.fileno()).st_size
             body_size = file_size - VERIFY_CACHE_FILE_HEADER_SIZE
             if body_size % VERIFY_CACHE_RECORD_SIZE != 0:
                 raise HeaderArchiveFormatError(

--- a/otsclient/headers.py
+++ b/otsclient/headers.py
@@ -1016,4 +1016,163 @@ class BitcoinP2PHeaderFetcher:
                     next_log_at += log_every
 
 
+# Bootstrap a header archive from a URL.
+#
+# `ots headers fetch --p2p` builds an archive in minutes; for users who'd
+# rather not even spend the minutes, a prebuilt archive can be downloaded
+# from any URL (GitHub Releases, IPFS, a friend's mirror, a magnet-extracted
+# file via file://). The trust model is identical to a self-built archive:
+# every header is validated against PoW + prev-hash continuity before the
+# file is installed. The source URL doesn't have to be trusted -- the math
+# is the trust signal. A tampered file fails validation; a benign mirror
+# just speeds things up.
+
+BOOTSTRAP_DEFAULT_TIMEOUT = 60
+BOOTSTRAP_DOWNLOAD_CHUNK = 1024 * 1024  # 1 MB
+
+
+def _walk_validate_archive(path, expected_network, partial_hint=None):
+    """Open the archive at `path`, walk every header, verify PoW + continuity.
+
+    Returns (network, start_height, header_count) on success. Raises
+    HeaderArchiveError or subclass on any validation failure. `partial_hint`
+    is appended to error messages so callers can point users at the
+    preserved partial download.
+    """
+    archive = HeaderArchive(path)
+    network, start_height, header_count = archive.read_file_header()
+    if network != expected_network:
+        suffix = " (partial preserved at %s)" % partial_hint if partial_hint else ""
+        raise HeaderArchiveNetworkMismatch(
+            "Archive network %r does not match expected %r%s" % (
+                network, expected_network, suffix))
+
+    if header_count == 0:
+        return network, start_height, header_count
+
+    with open(path, 'rb') as fd:
+        fd.seek(ARCHIVE_FILE_HEADER_SIZE)
+        prev_hash = None
+        for i in range(header_count):
+            height = start_height + i
+            raw = fd.read(BLOCK_HEADER_SIZE)
+            if len(raw) != BLOCK_HEADER_SIZE:
+                suffix = " (partial preserved at %s)" % partial_hint if partial_hint else ""
+                raise HeaderArchiveFormatError(
+                    "Truncated header at height %d%s" % (height, suffix))
+            header = bitcoin.core.CBlockHeader.deserialize(raw)
+            try:
+                bitcoin.core.CheckProofOfWork(header.GetHash(), header.nBits)
+            except bitcoin.core.CheckProofOfWorkError as exp:
+                suffix = " (partial preserved at %s)" % partial_hint if partial_hint else ""
+                raise HeaderArchiveChainError(
+                    "Header at height %d fails proof-of-work check: %s%s" % (
+                        height, exp, suffix))
+            if prev_hash is not None and header.hashPrevBlock != prev_hash:
+                suffix = " (partial preserved at %s)" % partial_hint if partial_hint else ""
+                raise HeaderArchiveChainError(
+                    "Header at height %d does not chain to height %d: "
+                    "prev_block_hash=%s, expected=%s%s" % (
+                        height, height - 1,
+                        header.hashPrevBlock.hex(), prev_hash.hex(), suffix))
+            prev_hash = header.GetHash()
+
+    return network, start_height, header_count
+
+
+def bootstrap_archive_from_url(url, output_path, network,
+                               expected_sha256=None,
+                               timeout=BOOTSTRAP_DEFAULT_TIMEOUT,
+                               progress_chunk_mb=10,
+                               log=True):
+    """Download a prebuilt header archive from `url` and install it locally.
+
+    The downloaded file is written to `<output_path>.partial`, validated
+    end-to-end (network match + PoW + prev-hash continuity for every
+    header), then atomically renamed to `output_path`. If validation
+    fails, the .partial file is left in place for inspection.
+
+    The trust signal is the per-header math, not the source URL. So the
+    URL can be any scheme `urllib.request` supports: http(s), file://,
+    ftp, etc. The optional `expected_sha256` adds an integrity precheck
+    against tampering or corruption-in-transit -- recommended when the
+    URL points at a third-party host.
+
+    Returns a dict {path, network, start_height, header_count, sha256}
+    on success. Raises HeaderArchiveError (or subclass) on any failure.
+    """
+    if expected_sha256 is not None:
+        expected_sha256 = expected_sha256.lower()
+
+    partial_path = output_path + '.partial'
+    os.makedirs(os.path.dirname(output_path) or '.', exist_ok=True)
+
+    if log:
+        logging.info("Downloading header archive from %s" % url)
+
+    progress_every = progress_chunk_mb * 1024 * 1024 if progress_chunk_mb else 0
+    next_log_at = progress_every
+    bytes_so_far = 0
+    hasher = hashlib.sha256()
+
+    try:
+        req = urllib.request.Request(
+            url, headers={'User-Agent': 'OpenTimestamps-Client headers-bootstrap'})
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            with open(partial_path, 'wb') as fd:
+                while True:
+                    buf = resp.read(BOOTSTRAP_DOWNLOAD_CHUNK)
+                    if not buf:
+                        break
+                    fd.write(buf)
+                    hasher.update(buf)
+                    bytes_so_far += len(buf)
+                    if progress_every and bytes_so_far >= next_log_at and log:
+                        logging.info("... downloaded %d MB" % (
+                            bytes_so_far // (1024 * 1024)))
+                        next_log_at += progress_every
+    except Exception as exp:
+        raise HeaderArchiveError(
+            "Failed to download from %s: %s (partial preserved at %s)" % (
+                url, exp, partial_path))
+
+    if log:
+        logging.info("Downloaded %d bytes" % bytes_so_far)
+
+    actual_sha256 = hasher.hexdigest()
+    if expected_sha256 is not None and actual_sha256 != expected_sha256:
+        raise HeaderArchiveError(
+            "SHA-256 mismatch: expected %s, got %s "
+            "(partial preserved at %s)" % (
+                expected_sha256, actual_sha256, partial_path))
+
+    if log:
+        logging.info(
+            "Validating archive (PoW + chain continuity, every header)...")
+    try:
+        network_in_file, start_height, header_count = _walk_validate_archive(
+            partial_path, network, partial_hint=partial_path)
+    except HeaderArchiveError:
+        # Already includes "partial preserved at ..." in the message.
+        raise
+
+    if log:
+        end_h = start_height + header_count - 1 if header_count > 0 else start_height
+        logging.info("Validated %d header(s) (heights %d..%d)" % (
+            header_count, start_height, end_h))
+
+    # Atomic install. os.replace overwrites an existing file if present.
+    os.replace(partial_path, output_path)
+    if log:
+        logging.info("Installed archive at %s" % output_path)
+
+    return {
+        'path': output_path,
+        'network': network_in_file,
+        'start_height': start_height,
+        'header_count': header_count,
+        'sha256': actual_sha256,
+    }
+
+
 # vim:syntax=python filetype=python

--- a/otsclient/headers.py
+++ b/otsclient/headers.py
@@ -572,6 +572,102 @@ class VerifyCache:
             fd.write(struct.pack('<I', height) + header.serialize())
 
 
+class LocalVerifyCacheHeaderSource(BlockHeaderSource):
+    """BlockHeaderSource backed by a sparse VerifyCache file.
+
+    Symmetric with LocalArchiveHeaderSource (which wraps the dense
+    HeaderArchive format) so a single --headers PATH can transparently
+    read either: see detect_archive_format() and the dispatch in
+    args.get_header_source().
+    """
+
+    def __init__(self, cache):
+        self.cache = cache
+
+    def get_header_at_height(self, height):
+        header = self.cache.get(height)
+        if header is None:
+            raise IndexError(
+                "Height %d not found in verify cache %s" % (height, self.cache.path))
+        return header
+
+    def get_block_count(self):
+        # VerifyCache is sparse: "tip" isn't meaningful. Return the
+        # highest cached height as a best-effort answer.
+        highest = -1
+        for height, _header in self.cache.iter_records():
+            if height > highest:
+                highest = height
+        return highest if highest >= 0 else 0
+
+
+def detect_archive_format(path):
+    """Read the first 4 bytes of `path` and return the magic.
+
+    Returns one of ARCHIVE_MAGIC, VERIFY_CACHE_MAGIC, or the raw bytes
+    if neither matches. Callers can dispatch on this to read either
+    format from the same --headers PATH.
+    """
+    with open(path, 'rb') as fd:
+        magic = fd.read(4)
+    return magic
+
+
+def build_sidecar_from_heights(heights, output_path, network, fetcher,
+                               force=False, log=True):
+    """Build a sparse-archive sidecar covering the given Bitcoin block heights.
+
+    Fetch each height's header via `fetcher` (quorum across HTTP sources),
+    validate PoW, and write the (height, header) records to a new
+    VerifyCache at `output_path`. The resulting file is a self-contained
+    sidecar that a recipient can pass to `ots verify --headers <path>`
+    to verify offline, without an OTS installation, a Bitcoin node, or
+    network access.
+
+    This is a pure cache-building primitive: callers (e.g., the CLI
+    handler in cmds.py) are responsible for sourcing the heights from
+    .ots files (or wherever else). Keeping .ots parsing out of headers.py
+    avoids pulling in opentimestamps.core dependencies here.
+
+    Raises HeaderArchiveError on fetch failure, quorum failure, or if
+    the output path already exists and `force` is False.
+    """
+    if os.path.exists(output_path) and not force:
+        raise HeaderArchiveError(
+            "Output path already exists: %s "
+            "(pass --force to overwrite)" % output_path)
+
+    if not heights:
+        raise HeaderArchiveError("No heights provided; nothing to build")
+
+    # Order heights for predictable on-disk record order and logging.
+    heights = sorted(set(heights))
+    if log:
+        logging.info(
+            "Building sidecar for %d Bitcoin attestation height(s): %s" % (
+                len(heights), ', '.join(str(h) for h in heights)))
+
+    # If overwriting, remove the old file so VerifyCache.create() succeeds.
+    if os.path.exists(output_path):
+        os.unlink(output_path)
+    cache = VerifyCache(output_path)
+    cache.create(network)
+    for height in heights:
+        if log:
+            logging.info("Fetching block %d header..." % height)
+        header = fetcher.fetch_header(height)
+        # VerifyCache.add validates PoW; trust signal is fetcher quorum
+        # plus that per-record PoW check.
+        cache.add(height, header)
+
+    return {
+        'path': output_path,
+        'network': network,
+        'heights': heights,
+        'header_count': len(heights),
+    }
+
+
 class AutoFetchHeaderSource(BlockHeaderSource):
     """Block header source that fetches lazily from public HTTP sources.
 

--- a/otsclient/tests/test_headers.py
+++ b/otsclient/tests/test_headers.py
@@ -9,6 +9,7 @@
 # modified, propagated, or distributed except according to the terms contained
 # in the LICENSE file.
 
+import hashlib
 import os
 import tempfile
 import unittest
@@ -32,9 +33,11 @@ from otsclient.headers import (
     P2PProtocolError,
     VerifyCache,
     AutoFetchHeaderSource,
+    bootstrap_archive_from_url,
     _P2PPeerSession,
     _read_p2p_message,
     _parse_headers_body,
+    _walk_validate_archive,
     ARCHIVE_MAGIC,
     ARCHIVE_FILE_HEADER_SIZE,
     BLOCK_HEADER_SIZE,
@@ -655,6 +658,212 @@ class TestP2PFetcher(unittest.TestCase):
         peers = [('1.2.3.4', 8333), ('5.6.7.8', 8333)]
         f = BitcoinP2PHeaderFetcher(peers=peers)
         self.assertEqual(f.get_peers(), peers)
+
+
+class _MockHTTPResponse:
+    """Mimics urllib.request.urlopen's return value for tests.
+
+    Supports the context-manager protocol and a chunked .read(n) interface.
+    """
+
+    def __init__(self, body):
+        self._body = body
+        self._pos = 0
+
+    def read(self, n=None):
+        if n is None or n < 0:
+            chunk = self._body[self._pos:]
+            self._pos = len(self._body)
+            return chunk
+        chunk = self._body[self._pos:self._pos + n]
+        self._pos += len(chunk)
+        return chunk
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+class TestBootstrapFromUrl(unittest.TestCase):
+
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.output_path = os.path.join(self._tmpdir.name, 'headers.bin')
+        self.genesis = genesis_header()
+
+        # Build a valid 1-header mainnet archive once and reuse the bytes
+        # as the "served" body for the mocked URL.
+        template = os.path.join(self._tmpdir.name, '_template.bin')
+        a = HeaderArchive(template)
+        a.create('mainnet', 0)
+        a.append_header(self.genesis)
+        with open(template, 'rb') as fd:
+            self.valid_archive_bytes = fd.read()
+        os.unlink(template)
+
+        # Pre-compute the SHA-256 of the valid archive for sha256 tests.
+        self.valid_sha256 = hashlib.sha256(self.valid_archive_bytes).hexdigest()
+
+    def tearDown(self):
+        self._tmpdir.cleanup()
+
+    def _patch_urlopen(self, body):
+        return mock.patch('urllib.request.urlopen',
+                          return_value=_MockHTTPResponse(body))
+
+    def test_happy_path(self):
+        """Valid archive at URL is downloaded, validated, installed atomically"""
+        with self._patch_urlopen(self.valid_archive_bytes):
+            info = bootstrap_archive_from_url(
+                'http://example.com/headers.bin',
+                self.output_path, 'mainnet', log=False)
+
+        self.assertEqual(info['network'], 'mainnet')
+        self.assertEqual(info['header_count'], 1)
+        self.assertEqual(info['start_height'], 0)
+        self.assertEqual(info['sha256'], self.valid_sha256)
+        self.assertTrue(os.path.isfile(self.output_path))
+        self.assertFalse(os.path.isfile(self.output_path + '.partial'))
+
+        # Installed file is byte-identical to served bytes.
+        with open(self.output_path, 'rb') as fd:
+            self.assertEqual(fd.read(), self.valid_archive_bytes)
+
+    def test_sha256_match_passes(self):
+        """Matching --sha256 succeeds"""
+        with self._patch_urlopen(self.valid_archive_bytes):
+            info = bootstrap_archive_from_url(
+                'http://example.com/headers.bin',
+                self.output_path, 'mainnet',
+                expected_sha256=self.valid_sha256, log=False)
+        self.assertEqual(info['sha256'], self.valid_sha256)
+
+    def test_sha256_mismatch_raises_and_no_install(self):
+        """Wrong --sha256 fails before validation, partial preserved"""
+        wrong_sha = '0' * 64
+        with self._patch_urlopen(self.valid_archive_bytes):
+            with self.assertRaises(HeaderArchiveError) as ctx:
+                bootstrap_archive_from_url(
+                    'http://example.com/headers.bin',
+                    self.output_path, 'mainnet',
+                    expected_sha256=wrong_sha, log=False)
+        self.assertIn('SHA-256 mismatch', str(ctx.exception))
+        self.assertFalse(os.path.isfile(self.output_path))
+        self.assertTrue(os.path.isfile(self.output_path + '.partial'))
+
+    def test_network_mismatch_raises(self):
+        """Archive built for one network rejected when caller expects another"""
+        with self._patch_urlopen(self.valid_archive_bytes):
+            with self.assertRaises(HeaderArchiveNetworkMismatch):
+                bootstrap_archive_from_url(
+                    'http://example.com/headers.bin',
+                    self.output_path, 'testnet', log=False)
+        self.assertFalse(os.path.isfile(self.output_path))
+        self.assertTrue(os.path.isfile(self.output_path + '.partial'))
+
+    def test_invalid_magic_raises(self):
+        """Body with wrong magic is rejected"""
+        bad_body = b'XXXX' + self.valid_archive_bytes[4:]
+        with self._patch_urlopen(bad_body):
+            with self.assertRaises(HeaderArchiveFormatError):
+                bootstrap_archive_from_url(
+                    'http://example.com/headers.bin',
+                    self.output_path, 'mainnet', log=False)
+        self.assertFalse(os.path.isfile(self.output_path))
+        self.assertTrue(os.path.isfile(self.output_path + '.partial'))
+
+    def test_pow_failure_raises_and_partial_preserved(self):
+        """A header that fails PoW is detected during validation"""
+        # Build an archive with a single header that fails PoW. We bypass
+        # HeaderArchive.append_header (which would reject it) and write
+        # the bytes directly.
+        bad_template = os.path.join(self._tmpdir.name, '_bad.bin')
+        a = HeaderArchive(bad_template)
+        a.create('mainnet', 0)
+        bad_header = bitcoin.core.CBlockHeader(
+            nVersion=2,
+            hashPrevBlock=b'\x00' * 32,
+            hashMerkleRoot=b'\x11' * 32,
+            nTime=0, nBits=0x1d00ffff, nNonce=0,
+        )
+        with open(bad_template, 'ab') as fd:
+            fd.write(bad_header.serialize())
+        with open(bad_template, 'rb') as fd:
+            bad_body = fd.read()
+        os.unlink(bad_template)
+
+        with self._patch_urlopen(bad_body):
+            with self.assertRaises(HeaderArchiveChainError) as ctx:
+                bootstrap_archive_from_url(
+                    'http://example.com/headers.bin',
+                    self.output_path, 'mainnet', log=False)
+        self.assertIn('proof-of-work', str(ctx.exception))
+        self.assertFalse(os.path.isfile(self.output_path))
+        self.assertTrue(os.path.isfile(self.output_path + '.partial'))
+
+    def test_overwrites_existing_output_atomically(self):
+        """A successful bootstrap replaces an existing output file"""
+        # Pre-populate output with junk
+        with open(self.output_path, 'wb') as fd:
+            fd.write(b'old contents')
+
+        with self._patch_urlopen(self.valid_archive_bytes):
+            bootstrap_archive_from_url(
+                'http://example.com/headers.bin',
+                self.output_path, 'mainnet', log=False)
+
+        with open(self.output_path, 'rb') as fd:
+            self.assertEqual(fd.read(), self.valid_archive_bytes)
+        self.assertFalse(os.path.isfile(self.output_path + '.partial'))
+
+    def test_download_failure_preserves_partial_message(self):
+        """A urllib failure surfaces a clear error mentioning the partial path"""
+        def _raising_urlopen(*a, **kw):
+            raise OSError("simulated network failure")
+
+        with mock.patch('urllib.request.urlopen', side_effect=_raising_urlopen):
+            with self.assertRaises(HeaderArchiveError) as ctx:
+                bootstrap_archive_from_url(
+                    'http://example.com/headers.bin',
+                    self.output_path, 'mainnet', log=False)
+        self.assertIn('Failed to download', str(ctx.exception))
+        self.assertIn('partial preserved', str(ctx.exception))
+        self.assertFalse(os.path.isfile(self.output_path))
+
+
+class TestWalkValidateArchive(unittest.TestCase):
+    """Direct tests of the bootstrap-time validation walker."""
+
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.path = os.path.join(self._tmpdir.name, 'headers.bin')
+
+    def tearDown(self):
+        self._tmpdir.cleanup()
+
+    def test_empty_archive_validates(self):
+        """A zero-header archive is valid (just the file header)"""
+        a = HeaderArchive(self.path)
+        a.create('mainnet', 0)
+        net, start, count = _walk_validate_archive(self.path, 'mainnet')
+        self.assertEqual(net, 'mainnet')
+        self.assertEqual(count, 0)
+
+    def test_genesis_validates(self):
+        """Single genesis header validates"""
+        a = HeaderArchive(self.path)
+        a.create('mainnet', 0)
+        a.append_header(genesis_header())
+        net, start, count = _walk_validate_archive(self.path, 'mainnet')
+        self.assertEqual(count, 1)
+
+    def test_network_mismatch_raises(self):
+        a = HeaderArchive(self.path)
+        a.create('mainnet', 0)
+        with self.assertRaises(HeaderArchiveNetworkMismatch):
+            _walk_validate_archive(self.path, 'testnet')
 
 
 # vim:syntax=python filetype=python

--- a/otsclient/tests/test_headers.py
+++ b/otsclient/tests/test_headers.py
@@ -12,9 +12,11 @@
 import os
 import tempfile
 import unittest
+from unittest import mock
 
 import bitcoin
 import bitcoin.core
+import bitcoin.messages
 
 from otsclient.headers import (
     HeaderArchive,
@@ -24,6 +26,12 @@ from otsclient.headers import (
     BlockHeaderSource,
     LocalArchiveHeaderSource,
     HeaderFetcher,
+    BitcoinP2PHeaderFetcher,
+    P2PFetcherError,
+    P2PProtocolError,
+    _P2PPeerSession,
+    _read_p2p_message,
+    _parse_headers_body,
     ARCHIVE_MAGIC,
     ARCHIVE_FILE_HEADER_SIZE,
     BLOCK_HEADER_SIZE,
@@ -279,6 +287,192 @@ class TestHeaderFetcher(unittest.TestCase):
             HeaderFetcher([s], quorum=0)
         with self.assertRaises(ValueError):
             HeaderFetcher([s], quorum=2)
+
+
+def _build_headers_message_body(headers):
+    """Serialize a list of CBlockHeaders into a P2P headers-message body.
+
+    Each entry is 80 bytes of header followed by a single 0x00 byte
+    (transaction-count varint = 0), matching the on-wire format.
+    """
+    import io
+    out = io.BytesIO()
+    bitcoin.core.VarIntSerializer.stream_serialize(len(headers), out)
+    for h in headers:
+        out.write(h.serialize())
+        out.write(b'\x00')  # transaction count varint = 0
+    return out.getvalue()
+
+
+def _frame_p2p_message(command, body):
+    """Wrap a body in P2P framing (magic + command + length + checksum)."""
+    import hashlib
+    import struct
+    cmd_padded = command + b'\x00' * (12 - len(command))
+    length = struct.pack(b'<I', len(body))
+    checksum = hashlib.sha256(hashlib.sha256(body).digest()).digest()[:4]
+    return bitcoin.params.MESSAGE_START + cmd_padded + length + checksum + body
+
+
+class _FakeSocket:
+    """A minimal socket stand-in for testing P2P session logic.
+
+    `recv_script` is a sequence of pre-framed messages the peer will
+    "send" back (consumed in order each time the session reads). All
+    `sendall()` calls are captured for later inspection.
+    """
+
+    def __init__(self, recv_script):
+        self.sent = []
+        self._recv_buf = b''.join(recv_script)
+
+    def sendall(self, data):
+        self.sent.append(data)
+
+    def makefile(self, mode='rb'):
+        import io
+        return io.BytesIO(self._recv_buf)
+
+    def close(self):
+        pass
+
+
+class TestP2PMessageParsing(unittest.TestCase):
+
+    def test_parse_headers_body_skips_trailing_byte(self):
+        """Header bodies on the wire have a 0-byte tx-count after each 80-byte header"""
+        # Two distinct, identifiable headers
+        h0 = bitcoin.core.CBlockHeader(
+            nVersion=1, hashPrevBlock=b'\x00' * 32,
+            hashMerkleRoot=b'\x11' * 32, nTime=1, nBits=0x1d00ffff, nNonce=10)
+        h1 = bitcoin.core.CBlockHeader(
+            nVersion=2, hashPrevBlock=b'\x22' * 32,
+            hashMerkleRoot=b'\x33' * 32, nTime=2, nBits=0x1d00ffff, nNonce=20)
+        body = _build_headers_message_body([h0, h1])
+        parsed = _parse_headers_body(body)
+        self.assertEqual(len(parsed), 2)
+        self.assertEqual(parsed[0].serialize(), h0.serialize())
+        self.assertEqual(parsed[1].serialize(), h1.serialize())
+
+    def test_parse_headers_body_truncated_raises(self):
+        """A body shorter than count * 80 bytes is rejected"""
+        # Claim 2 headers but include only 40 bytes of payload
+        import io
+        out = io.BytesIO()
+        bitcoin.core.VarIntSerializer.stream_serialize(2, out)
+        out.write(b'\x00' * 40)
+        with self.assertRaises(P2PProtocolError):
+            _parse_headers_body(out.getvalue())
+
+    def test_read_p2p_message_roundtrip(self):
+        """Properly framed message decodes to (command, body) with checksum check"""
+        import io
+        body = b'hello world'
+        framed = _frame_p2p_message(b'foo', body)
+        f = io.BytesIO(framed)
+        cmd, got_body = _read_p2p_message(f)
+        self.assertEqual(cmd, b'foo')
+        self.assertEqual(got_body, body)
+
+    def test_read_p2p_message_bad_magic_raises(self):
+        """Wrong magic bytes raise P2PProtocolError"""
+        import io
+        framed = b'WRONG' + b'\x00' * 100
+        f = io.BytesIO(framed)
+        with self.assertRaises(P2PProtocolError):
+            _read_p2p_message(f)
+
+    def test_read_p2p_message_bad_checksum_raises(self):
+        """Tampered body that no longer matches the framing checksum is rejected"""
+        import io
+        body = b'original'
+        framed = bytearray(_frame_p2p_message(b'foo', body))
+        # Flip a byte inside the body (past the 24-byte header)
+        framed[30] = framed[30] ^ 0xff
+        f = io.BytesIO(bytes(framed))
+        with self.assertRaises(P2PProtocolError):
+            _read_p2p_message(f)
+
+
+class TestP2PPeerSession(unittest.TestCase):
+
+    def _genesis_header(self):
+        gb = bitcoin.params.GENESIS_BLOCK
+        return gb.get_header() if hasattr(gb, 'get_header') else gb
+
+    def test_handshake_completes(self):
+        """Session completes version/verack exchange given canned peer responses"""
+        # Peer sends: version + verack
+        peer_messages = [
+            _frame_p2p_message(b'version', bitcoin.messages.msg_version().to_bytes()[24:]),
+            _frame_p2p_message(b'verack', b''),
+        ]
+        fake = _FakeSocket(peer_messages)
+
+        with mock.patch('socket.create_connection', return_value=fake):
+            with _P2PPeerSession('fake.example', 8333) as session:
+                # Reaching here means handshake succeeded
+                self.assertIsNotNone(session.sock)
+        # Two messages should have been sent: our version, then verack
+        self.assertEqual(len(fake.sent), 2)
+
+    def test_request_headers_returns_parsed_list(self):
+        """request_headers returns the headers from a canned 'headers' response"""
+        h0 = self._genesis_header()
+        peer_messages = [
+            _frame_p2p_message(b'version', bitcoin.messages.msg_version().to_bytes()[24:]),
+            _frame_p2p_message(b'verack', b''),
+            _frame_p2p_message(b'headers', _build_headers_message_body([h0])),
+        ]
+        fake = _FakeSocket(peer_messages)
+
+        with mock.patch('socket.create_connection', return_value=fake):
+            with _P2PPeerSession('fake.example', 8333) as session:
+                headers = session.request_headers(b'\x00' * 32)
+                self.assertEqual(len(headers), 1)
+                self.assertEqual(headers[0].serialize(), h0.serialize())
+
+    def test_request_headers_responds_to_ping(self):
+        """A 'ping' arriving before 'headers' is answered with 'pong'"""
+        import struct
+        h0 = self._genesis_header()
+        ping_body = struct.pack(b'<Q', 0x1234567890abcdef)
+        peer_messages = [
+            _frame_p2p_message(b'version', bitcoin.messages.msg_version().to_bytes()[24:]),
+            _frame_p2p_message(b'verack', b''),
+            _frame_p2p_message(b'ping', ping_body),
+            _frame_p2p_message(b'headers', _build_headers_message_body([h0])),
+        ]
+        fake = _FakeSocket(peer_messages)
+
+        with mock.patch('socket.create_connection', return_value=fake):
+            with _P2PPeerSession('fake.example', 8333) as session:
+                headers = session.request_headers(b'\x00' * 32)
+                self.assertEqual(len(headers), 1)
+        # Sent: our version, verack, getheaders, pong = 4 messages
+        self.assertEqual(len(fake.sent), 4)
+        # Last sent should be a pong containing the same nonce
+        last = fake.sent[-1]
+        self.assertEqual(last[4:4 + len(b'pong')].rstrip(b'\x00'), b'pong')
+
+
+class TestP2PFetcher(unittest.TestCase):
+
+    def test_rejects_non_genesis_archive(self):
+        """P2P fetcher refuses archives that don't start at genesis"""
+        with tempfile.TemporaryDirectory() as td:
+            p = os.path.join(td, 'partial.headers.bin')
+            archive = HeaderArchive(p)
+            archive.create('mainnet', 800000)
+            fetcher = BitcoinP2PHeaderFetcher(network='mainnet')
+            with self.assertRaises(P2PFetcherError):
+                fetcher.fetch_into(archive)
+
+    def test_constructor_holds_explicit_peers(self):
+        """Constructor stores explicit peers without invoking DNS"""
+        peers = [('1.2.3.4', 8333), ('5.6.7.8', 8333)]
+        f = BitcoinP2PHeaderFetcher(peers=peers)
+        self.assertEqual(f.get_peers(), peers)
 
 
 # vim:syntax=python filetype=python

--- a/otsclient/tests/test_headers.py
+++ b/otsclient/tests/test_headers.py
@@ -33,7 +33,10 @@ from otsclient.headers import (
     P2PProtocolError,
     VerifyCache,
     AutoFetchHeaderSource,
+    LocalVerifyCacheHeaderSource,
     bootstrap_archive_from_url,
+    build_sidecar_from_heights,
+    detect_archive_format,
     _P2PPeerSession,
     _read_p2p_message,
     _parse_headers_body,
@@ -658,6 +661,157 @@ class TestP2PFetcher(unittest.TestCase):
         peers = [('1.2.3.4', 8333), ('5.6.7.8', 8333)]
         f = BitcoinP2PHeaderFetcher(peers=peers)
         self.assertEqual(f.get_peers(), peers)
+
+
+class TestLocalVerifyCacheHeaderSource(unittest.TestCase):
+    """Verify cache wrapped as a BlockHeaderSource for --headers PATH."""
+
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.cache_path = os.path.join(self._tmpdir.name, 'verify-cache.bin')
+        self.genesis = genesis_header()
+
+    def tearDown(self):
+        self._tmpdir.cleanup()
+
+    def test_returns_cached_header(self):
+        c = VerifyCache(self.cache_path)
+        c.create('mainnet')
+        c.add(0, self.genesis)
+        src = LocalVerifyCacheHeaderSource(c)
+        out = src.get_header_at_height(0)
+        self.assertEqual(out.serialize(), self.genesis.serialize())
+
+    def test_missing_height_raises_indexerror(self):
+        c = VerifyCache(self.cache_path)
+        c.create('mainnet')
+        c.add(0, self.genesis)
+        src = LocalVerifyCacheHeaderSource(c)
+        with self.assertRaises(IndexError):
+            src.get_header_at_height(42)
+
+    def test_block_count_returns_highest(self):
+        c = VerifyCache(self.cache_path)
+        c.create('mainnet')
+        c.add(0, self.genesis)
+        c.add(42, self.genesis)  # PoW passes; we're just testing tip semantics
+        src = LocalVerifyCacheHeaderSource(c)
+        self.assertEqual(src.get_block_count(), 42)
+
+
+class TestDetectArchiveFormat(unittest.TestCase):
+
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+
+    def tearDown(self):
+        self._tmpdir.cleanup()
+
+    def test_detects_dense_archive(self):
+        path = os.path.join(self._tmpdir.name, 'a.bin')
+        a = HeaderArchive(path)
+        a.create('mainnet', 0)
+        self.assertEqual(detect_archive_format(path), ARCHIVE_MAGIC)
+
+    def test_detects_sparse_cache(self):
+        path = os.path.join(self._tmpdir.name, 'c.bin')
+        c = VerifyCache(path)
+        c.create('mainnet')
+        self.assertEqual(detect_archive_format(path), VERIFY_CACHE_MAGIC)
+
+    def test_unknown_magic_returned_as_is(self):
+        path = os.path.join(self._tmpdir.name, 'x.bin')
+        with open(path, 'wb') as fd:
+            fd.write(b'JUNK' + b'\x00' * 12)
+        magic = detect_archive_format(path)
+        self.assertEqual(magic, b'JUNK')
+        self.assertNotEqual(magic, ARCHIVE_MAGIC)
+        self.assertNotEqual(magic, VERIFY_CACHE_MAGIC)
+
+
+class TestBuildSidecarFromHeights(unittest.TestCase):
+
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.sidecar_path = os.path.join(self._tmpdir.name, 'side.bin')
+        self.genesis = genesis_header()
+
+    def tearDown(self):
+        self._tmpdir.cleanup()
+
+    def _make_fetcher(self, headers_by_height, fail_for=None):
+        s = _MockHeaderSource(headers_by_height, fail_for_heights=fail_for)
+        return HeaderFetcher([s], quorum=1)
+
+    def test_single_height_builds_sidecar(self):
+        """One height -> sparse cache with one record."""
+        fetcher = self._make_fetcher({358391: self.genesis})
+        info = build_sidecar_from_heights(
+            [358391], self.sidecar_path, 'mainnet', fetcher, log=False)
+        self.assertEqual(info['network'], 'mainnet')
+        self.assertEqual(info['header_count'], 1)
+        self.assertEqual(info['heights'], [358391])
+        self.assertTrue(os.path.isfile(self.sidecar_path))
+        # Sidecar is valid OTSV
+        self.assertEqual(detect_archive_format(self.sidecar_path),
+                         VERIFY_CACHE_MAGIC)
+        cache = VerifyCache(self.sidecar_path)
+        net, count = cache.read_file_header()
+        self.assertEqual(net, 'mainnet')
+        self.assertEqual(count, 1)
+
+    def test_multiple_heights_combined(self):
+        """Multiple heights produce one sidecar with all of them, sorted."""
+        fetcher = self._make_fetcher({
+            358391: self.genesis,
+            129405: self.genesis,
+        })
+        info = build_sidecar_from_heights(
+            [358391, 129405], self.sidecar_path, 'mainnet',
+            fetcher, log=False)
+        self.assertEqual(info['header_count'], 2)
+        # Heights are sorted for predictable on-disk order
+        self.assertEqual(info['heights'], [129405, 358391])
+
+    def test_duplicate_heights_deduped(self):
+        """Duplicate heights in input produce just one record each."""
+        fetcher = self._make_fetcher({100: self.genesis})
+        info = build_sidecar_from_heights(
+            [100, 100, 100], self.sidecar_path, 'mainnet',
+            fetcher, log=False)
+        self.assertEqual(info['header_count'], 1)
+        self.assertEqual(info['heights'], [100])
+
+    def test_empty_heights_raises(self):
+        """Empty heights list is a usage error."""
+        fetcher = self._make_fetcher({})
+        with self.assertRaises(HeaderArchiveError) as ctx:
+            build_sidecar_from_heights(
+                [], self.sidecar_path, 'mainnet', fetcher, log=False)
+        self.assertIn('No heights', str(ctx.exception))
+
+    def test_refuses_overwrite_without_force(self):
+        with open(self.sidecar_path, 'wb') as fd:
+            fd.write(b'preexisting')
+        fetcher = self._make_fetcher({100: self.genesis})
+        with self.assertRaises(HeaderArchiveError) as ctx:
+            build_sidecar_from_heights(
+                [100], self.sidecar_path, 'mainnet', fetcher,
+                force=False, log=False)
+        self.assertIn('already exists', str(ctx.exception))
+        with open(self.sidecar_path, 'rb') as fd:
+            self.assertEqual(fd.read(), b'preexisting')
+
+    def test_force_overwrites(self):
+        with open(self.sidecar_path, 'wb') as fd:
+            fd.write(b'preexisting')
+        fetcher = self._make_fetcher({100: self.genesis})
+        info = build_sidecar_from_heights(
+            [100], self.sidecar_path, 'mainnet', fetcher,
+            force=True, log=False)
+        self.assertEqual(info['header_count'], 1)
+        self.assertEqual(detect_archive_format(self.sidecar_path),
+                         VERIFY_CACHE_MAGIC)
 
 
 class _MockHTTPResponse:

--- a/otsclient/tests/test_headers.py
+++ b/otsclient/tests/test_headers.py
@@ -1,0 +1,284 @@
+# Copyright (C) 2026 The OpenTimestamps developers
+#
+# This file is part of the OpenTimestamps Client.
+#
+# It is subject to the license terms in the LICENSE file found in the top-level
+# directory of this distribution.
+#
+# No part of the OpenTimestamps Client, including this file, may be copied,
+# modified, propagated, or distributed except according to the terms contained
+# in the LICENSE file.
+
+import os
+import tempfile
+import unittest
+
+import bitcoin
+import bitcoin.core
+
+from otsclient.headers import (
+    HeaderArchive,
+    HeaderArchiveError,
+    HeaderArchiveFormatError,
+    HeaderArchiveChainError,
+    BlockHeaderSource,
+    LocalArchiveHeaderSource,
+    HeaderFetcher,
+    ARCHIVE_MAGIC,
+    ARCHIVE_FILE_HEADER_SIZE,
+    BLOCK_HEADER_SIZE,
+)
+
+
+def genesis_header():
+    """Return the mainnet genesis block as a CBlockHeader."""
+    gb = bitcoin.params.GENESIS_BLOCK
+    return gb.get_header() if hasattr(gb, 'get_header') else gb
+
+
+class _MockHeaderSource(BlockHeaderSource):
+    """Test helper: returns headers from a dict of {height: header}."""
+
+    def __init__(self, headers_by_height, fail_for_heights=None):
+        self.headers_by_height = dict(headers_by_height)
+        self.fail_for_heights = set(fail_for_heights or [])
+
+    def get_header_at_height(self, height):
+        if height in self.fail_for_heights:
+            raise ConnectionError("simulated failure for height %d" % height)
+        if height not in self.headers_by_height:
+            raise IndexError("no header at height %d" % height)
+        return self.headers_by_height[height]
+
+    def get_block_count(self):
+        return max(self.headers_by_height.keys()) if self.headers_by_height else 0
+
+
+class TestHeaderArchive(unittest.TestCase):
+
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.archive_path = os.path.join(self._tmpdir.name, 'test.headers.bin')
+
+    def tearDown(self):
+        self._tmpdir.cleanup()
+
+    def test_create_empty(self):
+        """Creating an empty archive writes a 16-byte file header"""
+        a = HeaderArchive(self.archive_path)
+        a.create('mainnet', 0)
+        info = a.info()
+        self.assertEqual(info['network'], 'mainnet')
+        self.assertEqual(info['start_height'], 0)
+        self.assertEqual(info['header_count'], 0)
+        self.assertEqual(info['file_size'], ARCHIVE_FILE_HEADER_SIZE)
+
+    def test_create_at_nonzero_start_height(self):
+        """Archive can be created starting at an arbitrary height"""
+        a = HeaderArchive(self.archive_path)
+        a.create('mainnet', 800000)
+        _net, start, count = a.read_file_header()
+        self.assertEqual(start, 800000)
+        self.assertEqual(count, 0)
+
+    def test_create_refuses_overwrite(self):
+        """Create on an existing file raises HeaderArchiveError"""
+        a = HeaderArchive(self.archive_path)
+        a.create('mainnet', 0)
+        with self.assertRaises(HeaderArchiveError):
+            a.create('mainnet', 0)
+
+    def test_genesis_roundtrip(self):
+        """Genesis block appends and reads back identically"""
+        a = HeaderArchive(self.archive_path)
+        a.create('mainnet', 0)
+        genesis = genesis_header()
+        a.append_header(genesis)
+
+        info = a.info()
+        self.assertEqual(info['header_count'], 1)
+        self.assertEqual(info['end_height'], 0)
+        self.assertEqual(info['file_size'], ARCHIVE_FILE_HEADER_SIZE + BLOCK_HEADER_SIZE)
+
+        h_back = a.get_header_at_height(0)
+        self.assertEqual(h_back.serialize(), genesis.serialize())
+
+    def test_out_of_range_height_raises(self):
+        """Asking for a height outside the archive's range raises IndexError"""
+        a = HeaderArchive(self.archive_path)
+        a.create('mainnet', 0)
+        a.append_header(genesis_header())
+        with self.assertRaises(IndexError):
+            a.get_header_at_height(1)
+        with self.assertRaises(IndexError):
+            a.get_header_at_height(-1)
+
+    def test_chain_continuity_check(self):
+        """Appending a header that does not chain to the previous one fails"""
+        a = HeaderArchive(self.archive_path)
+        a.create('mainnet', 0)
+        a.append_header(genesis_header())
+
+        # A header whose prev_block_hash is all zeros does not chain to genesis
+        fake = bitcoin.core.CBlockHeader(
+            nVersion=1,
+            hashPrevBlock=b'\x00' * 32,
+            hashMerkleRoot=b'\x00' * 32,
+            nTime=0,
+            nBits=0x1d00ffff,
+            nNonce=0,
+        )
+        with self.assertRaises(HeaderArchiveChainError):
+            a.append_header(fake)
+
+    def test_pow_check_rejects_invalid_pow(self):
+        """A header with nNonce=0 should fail PoW for the genesis difficulty"""
+        # Construct a "first block" header that does chain to genesis but has
+        # invalid PoW (random nonce that doesn't satisfy the target).
+        a = HeaderArchive(self.archive_path)
+        a.create('mainnet', 0)
+        a.append_header(genesis_header())
+
+        bad_header = bitcoin.core.CBlockHeader(
+            nVersion=1,
+            hashPrevBlock=genesis_header().GetHash(),
+            hashMerkleRoot=b'\x42' * 32,
+            nTime=1231469665,
+            nBits=0x1d00ffff,
+            nNonce=0,  # almost certainly does not satisfy the target
+        )
+        with self.assertRaises(HeaderArchiveChainError):
+            a.append_header(bad_header)
+
+    def test_format_magic_check(self):
+        """Reading a file with wrong magic raises HeaderArchiveFormatError"""
+        with open(self.archive_path, 'wb') as fd:
+            fd.write(b'NOPE' + b'\x00' * (ARCHIVE_FILE_HEADER_SIZE - 4))
+        a = HeaderArchive(self.archive_path)
+        with self.assertRaises(HeaderArchiveFormatError):
+            a.read_file_header()
+
+    def test_format_truncated_body(self):
+        """A file whose body isn't a multiple of 80 bytes raises FormatError"""
+        a = HeaderArchive(self.archive_path)
+        a.create('mainnet', 0)
+        # Append 40 bytes of garbage (half a header)
+        with open(self.archive_path, 'ab') as fd:
+            fd.write(b'\x00' * (BLOCK_HEADER_SIZE // 2))
+        with self.assertRaises(HeaderArchiveFormatError):
+            a.read_file_header()
+
+
+class TestLocalArchiveHeaderSource(unittest.TestCase):
+
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.archive_path = os.path.join(self._tmpdir.name, 'test.headers.bin')
+        self.archive = HeaderArchive(self.archive_path)
+        self.archive.create('mainnet', 0)
+        self.archive.append_header(genesis_header())
+        self.source = LocalArchiveHeaderSource(self.archive)
+
+    def tearDown(self):
+        self._tmpdir.cleanup()
+
+    def test_get_header_at_known_height(self):
+        """Source returns the same header that was archived"""
+        h = self.source.get_header_at_height(0)
+        self.assertEqual(h.serialize(), genesis_header().serialize())
+
+    def test_get_header_at_unknown_height_raises(self):
+        """Asking for an out-of-range height raises IndexError"""
+        with self.assertRaises(IndexError):
+            self.source.get_header_at_height(99999999)
+
+    def test_get_block_count(self):
+        """Block count reflects the highest stored height"""
+        self.assertEqual(self.source.get_block_count(), 0)
+
+
+class TestHeaderFetcher(unittest.TestCase):
+
+    def setUp(self):
+        self.header_a = genesis_header()
+        # A second distinct fake header for "disagreement" tests
+        self.header_b = bitcoin.core.CBlockHeader(
+            nVersion=2,
+            hashPrevBlock=b'\x00' * 32,
+            hashMerkleRoot=b'\x11' * 32,
+            nTime=0, nBits=0x1d00ffff, nNonce=0,
+        )
+
+    def test_single_source_pass(self):
+        """One source, quorum=1: returns the header unchanged"""
+        s = _MockHeaderSource({0: self.header_a})
+        f = HeaderFetcher([s], quorum=1)
+        out = f.fetch_header(0)
+        self.assertEqual(out.serialize(), self.header_a.serialize())
+
+    def test_quorum_agreement(self):
+        """Three sources agreeing meet quorum=2"""
+        s1 = _MockHeaderSource({0: self.header_a})
+        s2 = _MockHeaderSource({0: self.header_a})
+        s3 = _MockHeaderSource({0: self.header_a})
+        f = HeaderFetcher([s1, s2, s3], quorum=2)
+        out = f.fetch_header(0)
+        self.assertEqual(out.serialize(), self.header_a.serialize())
+
+    def test_quorum_majority_wins(self):
+        """Two sources agree, one disagrees: majority wins at quorum=2"""
+        s1 = _MockHeaderSource({0: self.header_a})
+        s2 = _MockHeaderSource({0: self.header_a})
+        s3 = _MockHeaderSource({0: self.header_b})
+        f = HeaderFetcher([s1, s2, s3], quorum=2)
+        out = f.fetch_header(0)
+        self.assertEqual(out.serialize(), self.header_a.serialize())
+
+    def test_quorum_failure_raises(self):
+        """No two sources agree: quorum=2 fails"""
+        s1 = _MockHeaderSource({0: self.header_a})
+        s2 = _MockHeaderSource({0: self.header_b})
+        # A third totally different header
+        header_c = bitcoin.core.CBlockHeader(
+            nVersion=3,
+            hashPrevBlock=b'\x00' * 32,
+            hashMerkleRoot=b'\x22' * 32,
+            nTime=0, nBits=0x1d00ffff, nNonce=0,
+        )
+        s3 = _MockHeaderSource({0: header_c})
+        f = HeaderFetcher([s1, s2, s3], quorum=2)
+        with self.assertRaises(HeaderArchiveError):
+            f.fetch_header(0)
+
+    def test_failing_source_does_not_block_quorum(self):
+        """One source erroring out shouldn't break quorum if others agree"""
+        s1 = _MockHeaderSource({0: self.header_a})
+        s2 = _MockHeaderSource({0: self.header_a})
+        s3 = _MockHeaderSource({}, fail_for_heights=[0])
+        f = HeaderFetcher([s1, s2, s3], quorum=2)
+        out = f.fetch_header(0)
+        self.assertEqual(out.serialize(), self.header_a.serialize())
+
+    def test_all_sources_failing_raises(self):
+        """If all sources fail, the fetcher raises"""
+        s1 = _MockHeaderSource({}, fail_for_heights=[0])
+        s2 = _MockHeaderSource({}, fail_for_heights=[0])
+        f = HeaderFetcher([s1, s2], quorum=1)
+        with self.assertRaises(HeaderArchiveError):
+            f.fetch_header(0)
+
+    def test_empty_sources_rejected(self):
+        """Cannot construct a fetcher with no sources"""
+        with self.assertRaises(ValueError):
+            HeaderFetcher([], quorum=1)
+
+    def test_invalid_quorum_rejected(self):
+        """Quorum must be in 1..len(sources)"""
+        s = _MockHeaderSource({0: self.header_a})
+        with self.assertRaises(ValueError):
+            HeaderFetcher([s], quorum=0)
+        with self.assertRaises(ValueError):
+            HeaderFetcher([s], quorum=2)
+
+
+# vim:syntax=python filetype=python

--- a/otsclient/tests/test_headers.py
+++ b/otsclient/tests/test_headers.py
@@ -23,18 +23,24 @@ from otsclient.headers import (
     HeaderArchiveError,
     HeaderArchiveFormatError,
     HeaderArchiveChainError,
+    HeaderArchiveNetworkMismatch,
     BlockHeaderSource,
     LocalArchiveHeaderSource,
     HeaderFetcher,
     BitcoinP2PHeaderFetcher,
     P2PFetcherError,
     P2PProtocolError,
+    VerifyCache,
+    AutoFetchHeaderSource,
     _P2PPeerSession,
     _read_p2p_message,
     _parse_headers_body,
     ARCHIVE_MAGIC,
     ARCHIVE_FILE_HEADER_SIZE,
     BLOCK_HEADER_SIZE,
+    VERIFY_CACHE_MAGIC,
+    VERIFY_CACHE_FILE_HEADER_SIZE,
+    VERIFY_CACHE_RECORD_SIZE,
 )
 
 
@@ -287,6 +293,182 @@ class TestHeaderFetcher(unittest.TestCase):
             HeaderFetcher([s], quorum=0)
         with self.assertRaises(ValueError):
             HeaderFetcher([s], quorum=2)
+
+
+class TestVerifyCache(unittest.TestCase):
+
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.cache_path = os.path.join(self._tmpdir.name, 'verify-cache.bin')
+        self.genesis = genesis_header()
+
+    def tearDown(self):
+        self._tmpdir.cleanup()
+
+    def test_create_empty(self):
+        """Creating a verify cache writes a 16-byte file header"""
+        c = VerifyCache(self.cache_path)
+        c.create('mainnet')
+        net, count = c.read_file_header()
+        self.assertEqual(net, 'mainnet')
+        self.assertEqual(count, 0)
+        self.assertEqual(os.path.getsize(self.cache_path),
+                         VERIFY_CACHE_FILE_HEADER_SIZE)
+
+    def test_magic_written(self):
+        """File header begins with the OTSV magic bytes"""
+        c = VerifyCache(self.cache_path)
+        c.create('mainnet')
+        with open(self.cache_path, 'rb') as fd:
+            self.assertEqual(fd.read(4), VERIFY_CACHE_MAGIC)
+
+    def test_create_refuses_overwrite(self):
+        """Create on an existing file raises HeaderArchiveError"""
+        c = VerifyCache(self.cache_path)
+        c.create('mainnet')
+        with self.assertRaises(HeaderArchiveError):
+            c.create('mainnet')
+
+    def test_create_unknown_network_rejected(self):
+        """Unknown network name raises HeaderArchiveError"""
+        c = VerifyCache(self.cache_path)
+        with self.assertRaises(HeaderArchiveError):
+            c.create('mainnetx')
+
+    def test_add_and_get(self):
+        """Round-trip: add a header at a height, get it back"""
+        c = VerifyCache(self.cache_path)
+        c.create('mainnet')
+        c.add(0, self.genesis)
+        got = c.get(0)
+        self.assertIsNotNone(got)
+        self.assertEqual(got.serialize(), self.genesis.serialize())
+
+    def test_get_missing_returns_none(self):
+        """Looking up an absent height returns None, not an error"""
+        c = VerifyCache(self.cache_path)
+        c.create('mainnet')
+        self.assertIsNone(c.get(0))
+        c.add(0, self.genesis)
+        self.assertIsNone(c.get(1))
+
+    def test_iter_records(self):
+        """iter_records yields (height, header) in file order"""
+        c = VerifyCache(self.cache_path)
+        c.create('mainnet')
+        c.add(0, self.genesis)
+        c.add(42, self.genesis)  # PoW passes; height is just a label here
+        records = list(c.iter_records())
+        self.assertEqual(len(records), 2)
+        self.assertEqual(records[0][0], 0)
+        self.assertEqual(records[1][0], 42)
+        for _height, header in records:
+            self.assertEqual(header.serialize(), self.genesis.serialize())
+
+    def test_add_rejects_invalid_pow(self):
+        """A header whose hash doesn't satisfy nBits is rejected"""
+        c = VerifyCache(self.cache_path)
+        c.create('mainnet')
+        bad_header = bitcoin.core.CBlockHeader(
+            nVersion=2,
+            hashPrevBlock=b'\x00' * 32,
+            hashMerkleRoot=b'\x11' * 32,
+            nTime=0, nBits=0x1d00ffff, nNonce=0,
+        )
+        with self.assertRaises(HeaderArchiveChainError):
+            c.add(0, bad_header)
+
+    def test_bad_magic_rejected_on_read(self):
+        """A file with the wrong magic raises HeaderArchiveFormatError"""
+        with open(self.cache_path, 'wb') as fd:
+            fd.write(b'XXXX' + b'\x00' * (VERIFY_CACHE_FILE_HEADER_SIZE - 4))
+        c = VerifyCache(self.cache_path)
+        with self.assertRaises(HeaderArchiveFormatError):
+            c.read_file_header()
+
+    def test_truncated_record_rejected(self):
+        """A body size that's not a multiple of the record size is rejected"""
+        c = VerifyCache(self.cache_path)
+        c.create('mainnet')
+        # Append a partial record (4 bytes < 84).
+        with open(self.cache_path, 'ab') as fd:
+            fd.write(b'\x00\x00\x00\x00')
+        with self.assertRaises(HeaderArchiveFormatError):
+            c.read_file_header()
+
+
+class TestAutoFetchHeaderSource(unittest.TestCase):
+
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.cache_path = os.path.join(self._tmpdir.name, 'verify-cache.bin')
+        self.genesis = genesis_header()
+
+    def tearDown(self):
+        self._tmpdir.cleanup()
+
+    def _make_source(self, cache=None, header=None):
+        if header is None:
+            header = self.genesis
+        s = _MockHeaderSource({0: header})
+        fetcher = HeaderFetcher([s], quorum=1)
+        if cache is None:
+            cache = VerifyCache(self.cache_path)
+        return AutoFetchHeaderSource(cache, fetcher, 'mainnet', log=False), s
+
+    def test_empty_cache_fetches_and_caches(self):
+        """First lookup populates the cache from the fetcher"""
+        src, _s = self._make_source()
+        out = src.get_header_at_height(0)
+        self.assertEqual(out.serialize(), self.genesis.serialize())
+        self.assertTrue(os.path.isfile(self.cache_path))
+        cache = VerifyCache(self.cache_path)
+        cached = cache.get(0)
+        self.assertIsNotNone(cached)
+        self.assertEqual(cached.serialize(), self.genesis.serialize())
+
+    def test_second_lookup_uses_cache(self):
+        """A second lookup at the same height doesn't call the fetcher"""
+        cache = VerifyCache(self.cache_path)
+        src, mock_source = self._make_source(cache=cache)
+        src.get_header_at_height(0)
+        # Pop the source's data so a re-fetch would IndexError.
+        mock_source.headers_by_height.clear()
+        out = src.get_header_at_height(0)
+        self.assertEqual(out.serialize(), self.genesis.serialize())
+
+    def test_cache_none_disables_caching(self):
+        """cache=None: always fetches, never writes a file"""
+        s = _MockHeaderSource({0: self.genesis})
+        fetcher = HeaderFetcher([s], quorum=1)
+        src = AutoFetchHeaderSource(None, fetcher, 'mainnet', log=False)
+        src.get_header_at_height(0)
+        self.assertFalse(os.path.isfile(self.cache_path))
+
+    def test_network_mismatch_raises(self):
+        """An existing cache for a different network raises"""
+        cache = VerifyCache(self.cache_path)
+        cache.create('testnet')
+        src, _s = self._make_source(cache=cache)
+        with self.assertRaises(HeaderArchiveNetworkMismatch):
+            src.get_header_at_height(0)
+
+    def test_fetched_bad_pow_raises(self):
+        """A fetched header that fails PoW is rejected before caching"""
+        bad_header = bitcoin.core.CBlockHeader(
+            nVersion=2,
+            hashPrevBlock=b'\x00' * 32,
+            hashMerkleRoot=b'\x11' * 32,
+            nTime=0, nBits=0x1d00ffff, nNonce=0,
+        )
+        src, _s = self._make_source(header=bad_header)
+        with self.assertRaises(HeaderArchiveChainError):
+            src.get_header_at_height(0)
+        # Cache should not have been created on the bad-PoW path.
+        if os.path.isfile(self.cache_path):
+            cache = VerifyCache(self.cache_path)
+            _net, count = cache.read_file_header()
+            self.assertEqual(count, 0)
 
 
 def _build_headers_message_body(headers):

--- a/release-notes.md
+++ b/release-notes.md
@@ -53,6 +53,24 @@
   `--sha256 HEX` adds an integrity precheck. `--force` to overwrite an
   existing archive at the output path.
 
+* `ots headers fetch <file>.ots [<file>.ots ...]` (passing one or more
+  .ots files as positional arguments) now builds a sparse sidecar
+  archive covering only the Bitcoin block heights those proofs attest
+  to. The default output is derived from the .ots filename
+  (`<file>.ots-btc-headers.bin`) so the sidecar sits next to its proof,
+  matching the existing .ots / .ots.bak naming family. `ots verify
+  --headers <sidecar>.bin <file>.ots` works against either dense or
+  sparse archives -- the verify path detects the magic and dispatches
+  to the right source. Useful for shipping self-verifying disclosure
+  bundles where the recipient may not have OTS installed.
+
+* Internal refactor: shared `_deserialize_timestamp` and
+  `_extract_bitcoin_heights` helpers in `cmds.py` consolidate the
+  open-and-parse and walk-attestations patterns that were previously
+  inlined in `verify_command`, `info_command`, `prune_command`, and
+  `upgrade_command`. No user-visible behavior change for those four
+  commands; the sidecar code reuses the same helpers.
+
 ## v0.7.2
 
 * Now works in git worktrees

--- a/release-notes.md
+++ b/release-notes.md
@@ -12,6 +12,12 @@
   this enables air-gapped and archival-quality verification. Closes the
   "Lite-Client Support" item from TODO.md.
 
+* `ots headers fetch --p2p` uses Bitcoin's native P2P getheaders protocol
+  for bulk header sync (up to 2000 headers per round trip vs one per HTTP
+  call). DNS-seed discovery by default; `--p2p-peer host[:port]` to
+  override. Headers undergo the same PoW + previous-hash validation as
+  the HTTP path, so a single peer is sufficient.
+
 ## v0.7.2
 
 * Now works in git worktrees

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,5 +1,17 @@
 # OpenTimestamps Client Release Notes
 
+## Unreleased
+
+* New `ots headers` subcommand group (`fetch`, `info`) plus a new `--headers`
+  flag on `ots verify` enable verification of Bitcoin-anchored timestamps
+  against a local archive of Bitcoin block headers, with no local Bitcoin
+  node and no network access at verify time. The archive is built by
+  cross-validating multiple Esplora-compatible sources at fetch time, with
+  per-header proof-of-work and previous-hash continuity checks at append
+  time. At 80 bytes per header (~70 MB for the entire Bitcoin chain),
+  this enables air-gapped and archival-quality verification. Closes the
+  "Lite-Client Support" item from TODO.md.
+
 ## v0.7.2
 
 * Now works in git worktrees

--- a/release-notes.md
+++ b/release-notes.md
@@ -42,6 +42,17 @@
   named `headers.bin` are not migrated automatically; pass
   `--output <cache_dir>/headers.bin` to keep using one, or rename it.
 
+* New `ots headers bootstrap <url>` subcommand downloads a prebuilt
+  header archive from any URL (`http(s)://`, `file://`, etc.), validates
+  it end-to-end against PoW + prev-hash continuity, and atomically
+  installs it. Useful for grabbing a snapshot from GitHub Releases,
+  IPFS, a mirror, or a magnet-extracted file without spending the
+  minutes a P2P fetch (or hours an HTTP fetch) would take. The trust
+  model is identical to a self-built archive -- math is the trust
+  signal, so the URL host doesn't have to be trusted. Optional
+  `--sha256 HEX` adds an integrity precheck. `--force` to overwrite an
+  existing archive at the output path.
+
 ## v0.7.2
 
 * Now works in git worktrees

--- a/release-notes.md
+++ b/release-notes.md
@@ -18,6 +18,30 @@
   override. Headers undergo the same PoW + previous-hash validation as
   the HTTP path, so a single peer is sufficient.
 
+* `ots verify` no longer requires `--bitcoin-node` or `--headers` to find
+  block headers. When neither flag is given, the no-flag path first
+  probes for a reachable local Bitcoin Core node (short-timeout RPC
+  ping against the default config) and uses it when present --
+  preserving the historical "I run `bitcoind`, just use it" behavior.
+  When no node responds, headers for the attested heights are
+  auto-fetched from public Esplora-compatible sources with quorum
+  agreement and cached on disk (in
+  `<cache_dir>/verify-cache-<network>.bin`) so subsequent verifications
+  of the same proof are network-free. The trust signal is unchanged:
+  per-header proof-of-work + quorum across multiple independent sources.
+  An info-level log line names which path was taken
+  ("Using local Bitcoin Core node ..." vs "Fetching block N header ...")
+  so privacy-conscious users see at a glance whether their proof hit a
+  third party. `--no-cache` disables the verify cache (and the existing
+  timestamp cache) for one-shot invocations.
+
+* `ots headers fetch` default `--output` path is now network-suffixed
+  (`<cache_dir>/headers-<network>.bin`) for the same reason: a mainnet
+  archive and a testnet archive used to collide on the same default
+  path and trigger a network-mismatch error. Existing local archives
+  named `headers.bin` are not migrated automatically; pass
+  `--output <cache_dir>/headers.bin` to keep using one, or rename it.
+
 ## v0.7.2
 
 * Now works in git worktrees


### PR DESCRIPTION
Howdy @petertodd . As you'd hinted at in the notes verifying a Bitcoin-anchored OTS proof traditionally needs a local Bitcoin Core node, because the verify path ends at a `BitcoinBlockHeaderAttestation` and we need the block header's `merkleroot` field to check the proof. At 80 bytes per block that's the *only* thing about the chain we need, and the whole chain since 2009 is around ~75 MBs. This is small enough to keep locally as a one-time fetch instead of running and indexing a node.

This set of changes adds an `ots headers` subcommand that maintains a small append-only archive of Bitcoin block headers, plus an `ots verify --headers <path>` option that consults the archive instead of a node. The archive format is a 16-byte file header (magic `OTSH`, version, network id, start_height) followed by raw 80-byte headers. Append-time validation requires proof-of-work and previous-hash continuity from the last stored header, so the file is self-checking on every extend.

Two reviewable commits, taken in order or independently:

**Commit 1: `Add lite-client support: local Bitcoin header archive for verification`** -- introduces `HeaderArchive`, the `BlockHeaderSource` abstraction (`BitcoinNodeHeaderSource` wraps the existing `--bitcoin-node` path; `LocalArchiveHeaderSource` is the new offline path), and an `EsploraHeaderFetcher` that pulls from Esplora-compatible HTTP sources (`blockstream.info`, `mempool.space`, etc.) with cross-source quorum agreement. The verify path is unchanged except that it consults `args.get_header_source()` instead of going straight to `bitcoin_node`. `--headers` and `--bitcoin-node` are mutually exclusive at verify time; stamping is unaffected.

**Commit 2: `Add Bitcoin P2P getheaders fetcher for fast bulk header sync`** -- the HTTP fetcher is fine for small ranges (per-bundle sidecar archives) but impractical for full-chain populating, since 950K+ HTTP calls against rate-limited public explorers means days. Bitcoin's native P2P `getheaders` message returns up to 2000 headers per round trip, turning a full-chain fetch into ~475 round trips, which is minutes against a fast peer. The new `BitcoinP2PHeaderFetcher` does the same drop-in role as `EsploraHeaderFetcher`: connect (DNS seed discovery by default, or explicit `--p2p-peer host[:port]`), handshake, `getheaders` loop, hand each result to `HeaderArchive.append_header` which already validates PoW + prev-hash. PoW validation is the trust signal, so a single peer is sufficient. A malicious peer can only feed us a chain that fails PoW, which we catch at append time and try the next peer.

Usage:

```
$ ots headers fetch --p2p
Fetching headers via Bitcoin P2P to the chain tip
... fetched 5000 headers (at height 5000)
... fetched 10000 headers (at height 10000)
...
Done. Appended 949535 header(s); archive now covers 0..949534

$ ots headers info ~/.cache/opentimestamps/ots/headers.bin
Path:         .../headers.bin
Network:      mainnet
Header count: 949535
Height range: 0..949534
File size:    79560416 bytes

$ ots verify --headers .../headers.bin examples/hello-world.txt.ots
Success! Bitcoin block 358391 attests existence as of 2015-05-28 CEST
```

**Bug note**: One quirk worth flagging: `python-bitcoinlib`'s `CBlockHeader` deserializer reads exactly 80 bytes per header, but the P2P `headers` message wire format appends a 0-byte transaction-count varint after each header -- so `msg_headers.msg_deser` misaligns against real peers (header 1's `hashPrevBlock` ends up shifted by 1 byte). The round-trip-against-self serializer mirrors the bug, so the library's own tests pass. As a fix I intercepted the `headers` command at the framing layer in `_parse_headers_body` and parse the body inline with the correct stride. The underlying `python-bitcoinlib` bug is filed at petertodd/python-bitcoinlib#320; once that's fixed and released, this workaround can come out.

FWIW the design intentionally keeps the trust model narrow: the archive is just a sequence of headers, validated locally via PoW + chain continuity, so it doesn't matter where the bytes came from. P2P, HTTP explorers, a friend's USB stick, a torrent -- the verifier only believes what the math agrees with. A natural follow-up is a `ots headers bootstrap <url>` for one-shot trusted-snapshot download (GitHub Releases, IPFS, etc.), but that's additive and can be PRed separately (assuming you like the idea).

Two further follow-ups I'd like to bring as separate PRs after this one, if you're open to them:

1. **Auto-fetch on verify** -- have `ots verify <file>.ots` (no flags) inspect the proof, fetch only the needed heights into the default cache if not already present, then verify. Headers become invisible to most users; `--headers`/`--bitcoin-node` remain for explicit/air-gapped scenarios.
2. **Bootstrap from URL** -- the snapshot-download path above.

Both depend on this PR being accepted first, so I held them back to keep this one focused.

Tested on Python 3.12 + Windows 11 with the full chain fetched via P2P (~12 minutes against `seed.bitcoin.sipa.be` (nice to see Pieter is still a part of the network), archive validated by `ots headers info` and used to verify `examples/hello-world.txt.ots`). The 35 new tests in `otsclient/tests/test_headers.py` use mocked HTTP responses and a fake socket with pre-canned P2P responses, so they run in CI without network access.

Happy to split, reorder, or rework any of this in whatever way reviews easiest.

**Tests worth running**

- [ ] Local: `python -m unittest otsclient.tests.test_headers` (35 tests, no network)
- [ ] Local: full chain fetch via `ots headers fetch --p2p`, then `ots verify --headers <path> examples/hello-world.txt.ots`
- [ ] Verify path unchanged when neither `--headers` nor `--bitcoin-node` is provided (falls back to existing behavior)
- [ ] Cross-platform path resolution for default cache location (`appdirs`)

**Some additional notes**

- Both commits keep the existing project style: 4-space indent, no type hints, license header on new files, snake_case, prose docstrings.
- New code lives in `otsclient/headers.py` (one module per concern, matching the existing layout).
- `release-notes.md` has an "Unreleased" entry covering both commits.
- No new runtime dependencies beyond what's already in `setup.py` (`appdirs` is already used elsewhere for cache paths).
