### PR TITLE
Fix git gpg wrapper: Bitcoin node errors no longer block gpg verification

### DIFF
--- a/otsclient/args.py
+++ b/otsclient/args.py
@@ -142,11 +142,7 @@ def handle_common_options(args, parser):
         else:
             assert False
 
-        try:
-            return bitcoin.rpc.Proxy(service_url=args.bitcoin_node)
-        except Exception as exp:
-            logging.error("Could not connect to Bitcoin node: %s" % exp)
-            sys.exit(1)
+        return bitcoin.rpc.Proxy(service_url=args.bitcoin_node)
 
     args.setup_bitcoin = setup_bitcoin
 

--- a/otsclient/cmds.py
+++ b/otsclient/cmds.py
@@ -398,6 +398,8 @@ def verify_timestamp(timestamp, args):
             return 2**32-1
 
     good = False
+    bitcoin_proxy = None
+    bitcoin_connect_error = None
     for msg, attestation in sorted(timestamp.all_attestations(), key=attestation_key):
         if attestation.__class__ == PendingAttestation:
             # Handled by the upgrade_timestamp() call above.
@@ -410,21 +412,28 @@ def verify_timestamp(timestamp, args):
                                 (attestation.height, b2lx(msg)))
                 continue
 
+            if bitcoin_connect_error is not None:
+                continue
+
+            if bitcoin_proxy is None:
+                try:
+                    bitcoin_proxy = args.setup_bitcoin()
+                except Exception as exp:
+                    bitcoin_connect_error = exp
+                    logging.error("Could not connect to Bitcoin node: %s" % exp)
+                    continue
+
             try:
-                proxy = args.setup_bitcoin()
-                block_count = proxy.getblockcount()
-                blockhash = proxy.getblockhash(attestation.height)
+                block_count = bitcoin_proxy.getblockcount()
+                blockhash = bitcoin_proxy.getblockhash(attestation.height)
             except IndexError:
                 logging.error("Bitcoin block height %d not found; %d is highest known block" % (attestation.height, block_count))
                 continue
             except ConnectionError as exp:
                 logging.error("Could not connect to local Bitcoin node: %s" % exp)
                 continue
-            except Exception as exp:
-                logging.error("Could not connect to Bitcoin node: %s" % exp)
-                continue
 
-            block_header = proxy.getblockheader(blockhash)
+            block_header = bitcoin_proxy.getblockheader(blockhash)
 
             logging.debug("Attestation block hash: %s" % b2lx(blockhash))
 

--- a/otsclient/cmds.py
+++ b/otsclient/cmds.py
@@ -55,7 +55,11 @@ def create_timestamp(timestamp, calendar_urls, args):
 
     setup_bitcoin = args.setup_bitcoin if args.use_btc_wallet else False
     if setup_bitcoin:
-        proxy = setup_bitcoin()
+        try:
+            proxy = setup_bitcoin()
+        except Exception as exp:
+            logging.error("Could not connect to Bitcoin node: %s" % exp)
+            sys.exit(1)
 
         unfunded_tx = CTransaction([], [CTxOut(0, CScript([OP_RETURN, timestamp.msg]))])
         r = proxy.fundrawtransaction(unfunded_tx)  # FIXME: handle errors
@@ -406,9 +410,8 @@ def verify_timestamp(timestamp, args):
                                 (attestation.height, b2lx(msg)))
                 continue
 
-            proxy = args.setup_bitcoin()
-
             try:
+                proxy = args.setup_bitcoin()
                 block_count = proxy.getblockcount()
                 blockhash = proxy.getblockhash(attestation.height)
             except IndexError:
@@ -416,6 +419,9 @@ def verify_timestamp(timestamp, args):
                 continue
             except ConnectionError as exp:
                 logging.error("Could not connect to local Bitcoin node: %s" % exp)
+                continue
+            except Exception as exp:
+                logging.error("Could not connect to Bitcoin node: %s" % exp)
                 continue
 
             block_header = proxy.getblockheader(blockhash)
@@ -517,9 +523,8 @@ def verify_all_attestations(timestamp, attestations_to_verify, args):
                     logging.error("Bitcoin disabled, could not check attestations")
                     sys.exit(1)
 
-                proxy = args.setup_bitcoin()
-
                 try:
+                    proxy = args.setup_bitcoin()
                     block_count = proxy.getblockcount()
                     blockhash = proxy.getblockhash(attestation.height)
                     block_header = proxy.getblockheader(blockhash)
@@ -533,6 +538,9 @@ def verify_all_attestations(timestamp, attestations_to_verify, args):
                     sys.exit(1)
                 except VerificationError as err:
                     logging.error("Bitcoin verification failed: %s" % str(err))
+                    sys.exit(1)
+                except Exception as exp:
+                    logging.error("Could not connect to Bitcoin node: %s" % exp)
                     sys.exit(1)
 
             else:

--- a/otsclient/cmds.py
+++ b/otsclient/cmds.py
@@ -430,6 +430,7 @@ def verify_timestamp(timestamp, args):
                 logging.error("Bitcoin block height %d not found; %d is highest known block" % (attestation.height, block_count))
                 continue
             except ConnectionError as exp:
+                bitcoin_connect_error = exp
                 logging.error("Could not connect to local Bitcoin node: %s" % exp)
                 continue
 

--- a/otsclient/tests/test_cmds.py
+++ b/otsclient/tests/test_cmds.py
@@ -51,7 +51,7 @@ class TestVerifyTimestampBitcoinUnreachable(unittest.TestCase):
 
         self.assertFalse(good)
 
-    def test_unreachable_bitcoin_node_logs_once(self):
+    def test_unreachable_bitcoin_node_calls_setup_bitcoin_once(self):
         t = self._make_timestamp([100, 200, 300])
         setup_bitcoin = Mock(side_effect=Exception("Cookie file unusable"))
         args = self._make_args(setup_bitcoin)
@@ -60,3 +60,16 @@ class TestVerifyTimestampBitcoinUnreachable(unittest.TestCase):
 
         self.assertFalse(good)
         self.assertEqual(setup_bitcoin.call_count, 1)
+
+    def test_bitcoin_node_disconnect_mid_rpc_calls_getblockcount_once(self):
+        t = self._make_timestamp([100, 200, 300])
+        proxy = Mock()
+        proxy.getblockcount = Mock(side_effect=ConnectionError("Connection reset"))
+        setup_bitcoin = Mock(return_value=proxy)
+        args = self._make_args(setup_bitcoin)
+
+        good = verify_timestamp(t, args)
+
+        self.assertFalse(good)
+        self.assertEqual(setup_bitcoin.call_count, 1)
+        self.assertEqual(proxy.getblockcount.call_count, 1)

--- a/otsclient/tests/test_cmds.py
+++ b/otsclient/tests/test_cmds.py
@@ -1,0 +1,62 @@
+# Copyright (C) 2026 The OpenTimestamps developers
+#
+# This file is part of the OpenTimestamps Client.
+#
+# It is subject to the license terms in the LICENSE file found in the top-level
+# directory of this distribution.
+#
+# No part of the OpenTimestamps Client, including this file, may be copied,
+# modified, propagated, or distributed except according to the terms contained
+# in the LICENSE file.
+
+import types
+import unittest
+from unittest.mock import Mock
+
+from opentimestamps.core.timestamp import Timestamp
+from opentimestamps.core.op import OpAppend
+from opentimestamps.core.notary import BitcoinBlockHeaderAttestation
+
+from otsclient.cache import TimestampCache
+from otsclient.cmds import verify_timestamp
+
+
+class TestVerifyTimestampBitcoinUnreachable(unittest.TestCase):
+    """verify_timestamp() must not let a Bitcoin RPC connection failure abort the
+    process; the git gpg wrapper relies on it always returning so it can still
+    invoke gpg regardless of the OTS verification outcome."""
+
+    def _make_timestamp(self, heights):
+        t = Timestamp(b'\x00' * 32)
+        for i, height in enumerate(heights):
+            sub = t.ops.add(OpAppend(bytes([i])))
+            sub.attestations = {BitcoinBlockHeaderAttestation(height)}
+        return t
+
+    def _make_args(self, setup_bitcoin):
+        return types.SimpleNamespace(
+            calendar_urls=[],
+            cache=TimestampCache(None),
+            wait=False,
+            use_bitcoin=True,
+            setup_bitcoin=setup_bitcoin,
+        )
+
+    def test_unreachable_bitcoin_node_does_not_raise(self):
+        t = self._make_timestamp([100])
+        setup_bitcoin = Mock(side_effect=Exception("Cookie file unusable"))
+        args = self._make_args(setup_bitcoin)
+
+        good = verify_timestamp(t, args)
+
+        self.assertFalse(good)
+
+    def test_unreachable_bitcoin_node_logs_once(self):
+        t = self._make_timestamp([100, 200, 300])
+        setup_bitcoin = Mock(side_effect=Exception("Cookie file unusable"))
+        args = self._make_args(setup_bitcoin)
+
+        good = verify_timestamp(t, args)
+
+        self.assertFalse(good)
+        self.assertEqual(setup_bitcoin.call_count, 1)


### PR DESCRIPTION
## What
Fixes `otsclient.cmds.verify_timestamp()` so a Bitcoin RPC connection failure never aborts the process before `gpg` is invoked, and stops that failure from being retried/logged once per attestation.

## Why
`git verify-commit` / `git log --show-signature` invoke `ots-git-gpg-wrapper` as `gpg.program`. In the `--verify` path, the wrapper calls `verify_timestamp()` and is only supposed to log the OTS outcome as a warning before always invoking `gpg`. `setup_bitcoin()` called `sys.exit(1)` when the Bitcoin RPC connection failed (e.g. unusable cookie file), aborting the whole wrapper process before `gpg` ever ran. Git then marked commits as unverified (`N`) even when they carried a valid `gpgsig` — inconsistent with the existing "pending calendar" OTS failure path, which already logged and continued.

## Changes
- `otsclient/args.py`: `setup_bitcoin()` now raises instead of calling `sys.exit(1)`, letting each call site decide whether a connection failure is fatal.
- `otsclient/cmds.py`:
  - `create_timestamp()` (stamp with `-b`/wallet) and `verify_all_attestations()` (prune `--verify`) wrap the call and keep the previous exit-on-failure behavior.
  - `verify_timestamp()` (used by the git gpg wrapper) now catches the failure, logs an error, and returns normally instead of raising — matching the existing pending-timestamp behavior.
  - Same function: caches a Bitcoin connection failure (both at `setup_bitcoin()` and mid-RPC on `ConnectionError` from `getblockcount`/`getblockhash`) so it's logged once per `verify_timestamp()` call instead of once per `BitcoinBlockHeaderAttestation`.
- `otsclient/tests/test_cmds.py` (new): regression tests covering that `verify_timestamp()` never raises on a Bitcoin connection failure, and that `setup_bitcoin()`/`getblockcount()` are each called only once across multiple attestations.
